### PR TITLE
fix(bom): custom filter to match kicad built-in + schematic PDF

### DIFF
--- a/Hardware/OpenMowerMainboard/OpenMowerMainboard.kibot.yaml
+++ b/Hardware/OpenMowerMainboard/OpenMowerMainboard.kibot.yaml
@@ -62,6 +62,13 @@ outputs:
       extra_fields: Stock_PN
       highlight_pin1: true
 
+  - name: 'pdf_sch_print'
+    comment: 'Exports the PCB to the most common exchange format. Suitable for printing.'
+    type: 'pdf_sch_print'
+    dir: 'release'
+    options:
+      dnf_filter: anything_in_Config
+
   - name: 'pcbdraw_svg'
     comment: 'Exports the PCB as a 2D model (SVG, PNG or JPG).'
     type: 'pcbdraw'

--- a/Hardware/OpenMowerMainboard/OpenMowerMainboard.kibot.yaml
+++ b/Hardware/OpenMowerMainboard/OpenMowerMainboard.kibot.yaml
@@ -7,11 +7,23 @@ preflight:
   set_text_variables:
     - name: 'git_version'
       command: 'git describe --tags'
+  update_xml: true
+
+filters:
+  - name: anything_in_Config
+    type: 'generic'
+    comment: 'Remove components with something in config'
+    keys: ["do not place", "DNP", 'bench_test']
+    exclude_config: true
+    exclude_value: true
 
 outputs:
   - name: 'bom'
-    type: 'bom'
+    comment: 'Used to generate the BoM in CSV, HTML, TSV, TXT, XML or XLSX format using the internal BoM.'
+    type: 'kibom'   # reads bom.ini in contrast with 'bom'
     dir: 'release'
+    options:
+      format: CSV
 
   - name: 'write_gerber_drill'
     comment: 'This is the information for the drilling machine in gerber format.'
@@ -38,11 +50,17 @@ outputs:
     comment: 'Generates the file with position information for the PCB components, used by the pick and place machine.'
     type: 'position'
     dir: 'release'
+    options:
+      dnf_filter: anything_in_Config
 
   - name: 'ibom'
     comment: 'Generates an interactive web page useful to identify the position of the components in the PCB.'
     type: 'ibom'
     dir: 'release'
+    options:
+      dnf_filter: anything_in_Config
+      extra_fields: Stock_PN
+      highlight_pin1: true
 
   - name: 'pcbdraw_svg'
     comment: 'Exports the PCB as a 2D model (SVG, PNG or JPG).'
@@ -50,6 +68,7 @@ outputs:
     dir: 'release'
     options:
       format: 'svg'
+      dnf_filter: anything_in_Config
 
   - name: 'pcbdraw_png'
     comment: 'Exports the PCB as a 2D model (SVG, PNG or JPG).'
@@ -57,6 +76,7 @@ outputs:
     dir: 'release'
     options:
       format: 'png'
+      dnf_filter: anything_in_Config
 
   - name: 'pcbdraw_svg_bottom'
     comment: 'Exports the PCB as a 2D model (SVG, PNG or JPG).'
@@ -65,6 +85,7 @@ outputs:
     options:
       bottom: true
       format: 'svg'
+      dnf_filter: anything_in_Config
 
   - name: 'pcbdraw_png_bottom'
     comment: 'Exports the PCB as a 2D model (SVG, PNG or JPG).'
@@ -73,6 +94,7 @@ outputs:
     options:
       bottom: true
       format: 'png'
+      dnf_filter: anything_in_Config
 
   - name: 'navigate_results'
     comment: 'Generates a web page to navigate the generated outputs'

--- a/Hardware/OpenMowerMainboard/bom.ini
+++ b/Hardware/OpenMowerMainboard/bom.ini
@@ -33,7 +33,7 @@ board_variant = ['default']
 ; Whether to hide headers from output file
 hide_headers = False
 ; Whether to hide PCB info from output file
-hide_pcb_info = False
+hide_pcb_info = True
 ; Interpret as a Digikey P/N and link the following field
 digikey_link = False
 


### PR DESCRIPTION
Fixes the issue when automatic KiCAD BOM (.csv) generator includes any parts that have something in `Config` field, but the rest of the generated files have DNFs (ibom, pick-and-place etc).
