### PR TITLE
feat: tag PCB with 2 digits out of 3

### DIFF
--- a/Hardware/OpenMowerMainboard/OpenMowerMainboard.kibot.yaml
+++ b/Hardware/OpenMowerMainboard/OpenMowerMainboard.kibot.yaml
@@ -6,7 +6,9 @@ preflight:
   run_drc: true
   set_text_variables:
     - name: 'git_version'
-      command: 'git describe --tags'
+      # Replace n.m.i with n.m."x"
+      command: >
+        git describe --tags | sed -E 's/^(v[0-9]+\.[0-9]+)\.([0-9]+)/\1.x/'
   update_xml: true
 
 filters:


### PR DESCRIPTION
We agreed to bump MINOR when PCB changes, and bump PATCH when software changes, so in order to have same PCB versions when software is upgraded we tag PCB with `v1.2.x` instead of `v1.2.3`, `v1.2.4`