### PR TITLE
Feature/support df player clones

### DIFF
--- a/Firmware/LowLevel/include/debug.h
+++ b/Firmware/LowLevel/include/debug.h
@@ -1,0 +1,53 @@
+// Created by Apehaenger on 02/02/23.
+//
+// This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//
+// Feel free to use the design in your private/educational projects, but don't try to sell the design or products based on it without getting my consent first.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//
+#ifndef _DEBUG_H_
+#define _DEBUG_H_
+
+// Define to stream debugging messages via USB
+//#define USB_DEBUG
+
+// Only define DEBUG_SERIAL if USB_DEBUG is actually enabled.
+// This enforces compile errors if it's used incorrectly.
+#ifdef USB_DEBUG
+#define DEBUG_SERIAL Serial
+#define DfMiniMp3Debug DEBUG_SERIAL
+// Some blody simple debug wrapper which superfluous '#ifdef USB_DEBUG' ...
+#define DEBUG_PRINT(s)            \
+    {                             \
+        DEBUG_SERIAL.print(F(s)); \
+    }
+#define DEBUG_PRINTLN(s)            \
+    {                               \
+        DEBUG_SERIAL.println(F(s)); \
+    }
+#define DEBUG_PRINT_VAL(v, f)     \
+    do                            \
+    {                             \
+        DEBUG_SERIAL.print(v, f); \
+    } while (0);
+#define DEBUG_PRINTLN_VAL(v, f)     \
+    do                              \
+    {                               \
+        DEBUG_SERIAL.println(v, f); \
+    } while (0);
+#else
+#define DEBUG_PRINT(s)
+#define DEBUG_PRINTLN(s)
+#define DEBUG_PRINT_VAL(v, f)
+#define DEBUG_PRINTLN_VAL(v, f)
+#endif
+
+#endif // _DEBUG_H_

--- a/Firmware/LowLevel/include/soundsystem.h
+++ b/Firmware/LowLevel/include/soundsystem.h
@@ -17,53 +17,59 @@
 #ifndef _SOUND_SYSTEM_H_
 #define _SOUND_SYSTEM_H_
 
-//#include <Arduino.h>
 #include <stdint.h>
 #include <list>
-
-#include <pins.h>
-#include <DFPlayerMini_Fast.h>
-#include <soundsystem.h>
-
+#include <DFMiniMp3.h>
 
 #define BUFFERSIZE 100
+#define DFP_ONLINE_TIMEOUT 6000
+#define DFP_CLONE_ERROR_TIMEOUT 200
 
+// BTW: While readinging on, take into account that c/cpp is an ancient programming language from the last century ...
 
+class MP3Sound;                               // forward declaration ...
+typedef DFMiniMp3<SerialPIO, MP3Sound> DfMp3; // ... for a more readable/shorter DfMp3 typedef
+
+// Non thread safe singleton MP3Sound class
 class MP3Sound
 {
+protected:
+    MP3Sound(); // Singleton constructors always should be private to prevent direct construction via 'new'
 
-   
-   
+    static MP3Sound *mp3sound_;
 
-    public:
+public:
+    int16_t anzSoundfiles; // number of files stored on the SD-card
+    bool playing;
 
-                int16_t anzSoundfiles;          // number of files stored on the SD-card
-                bool     playing;
+    static MP3Sound *GetInstance();
+    MP3Sound(MP3Sound &other) = delete;        // Singletons should not be cloneable
+    void operator=(const MP3Sound &) = delete; // Singletons should not be assignable
 
-                MP3Sound();
+    bool begin(); // init serial stream and soundmodule, anzsoundOnSD : maximum number of available soundfiles on the SD-card
 
-                bool begin();      // init serial stream and soundmodule, anzsoundOnSD : maximum number of available soundfiles on the SD-card
-                
-                void playSound(int soundNr);        // play soundfile number. This method writes soundfile nr in a list, the method processSounds() (has to run in loop) will play 
-                                                    // the sounds according to the list
+    void playSound(int soundNr); // play soundfile number. This method writes soundfile nr in a list, the method processSounds() (has to run in loop) will play
+                                 // the sounds according to the list
 
-                void playSoundAdHoc(int soundNr);   // play soundfile number immediately whithout waiting until the end of sound
+    void playSoundAdHoc(int soundNr); // play soundfile number immediately whithout waiting until the end of sound
 
-                void setvolume(int vol);            // scales loudness from 0 to 100 %
+    void setVolume(uint8_t vol); // scales loudness from 0 to 100 %
 
-                int sounds2play();                  // returns the number if sounds to play in the list
+    int sounds2play(); // returns the number if sounds to play in the list
 
-                int processSounds();                // play all sounds from the list. This method has to be calles cyclic, e.g. every second.
+    int processSounds(); // play all sounds from the list. This method has to be calles cyclic, e.g. every second.
 
-                
-    private:
-                std::list <int> active_sounds;
-                bool sound_available;
-                
+    // DFMiniMP3 specific notification methods
+    static void OnError(DfMp3 &mp3, uint16_t errorCode);
+    static void OnPlayFinished(DfMp3 &mp3, DfMp3_PlaySources source, uint16_t track){};
+    static void OnPlaySourceOnline(DfMp3 &mp3, DfMp3_PlaySources source){};
+    static void OnPlaySourceInserted(DfMp3 &mp3, DfMp3_PlaySources source){};
+    static void OnPlaySourceRemoved(DfMp3 &mp3, DfMp3_PlaySources source){};
 
-   
-
+private:
+    std::list<int> active_sounds;
+    bool sound_available;
+    bool reset_sent = false, received_clone_init_error = false;
 };
-
 
 #endif // _SOUND_SYSTEM_H_  HEADER_FILE

--- a/Firmware/LowLevel/platformio.ini
+++ b/Firmware/LowLevel/platformio.ini
@@ -10,13 +10,11 @@
 
 [common]
 ; common sources here
-default_src_filter = +<*> 
-    -<src/imu/>
+default_src_filter = +<*>
+                     -<src/imu/>
 
 [env]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
-platform_packages =
-	maxgerhardt/framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git
 board = pico
 framework = arduino
 board_build.core = earlephilhower
@@ -45,46 +43,58 @@ debug_build_flags = -O0 -g -ggdb
 build_src_filter = +<*> -<.git/> -<.svn/> -<imu/*> -<soundsystem.cpp>
 
 
+[env:0_11_X_MPU9250]
+lib_ignore = JY901_SERIAL,JY901_I2C
+lib_deps = ${env.lib_deps}
+           bolderflight/Bolder Flight Systems MPU9250@^1.0.2
+           https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
+build_src_filter = ${env.build_src_filter} +<imu/MPU9250/> +<soundsystem.cpp>
+build_flags = ${env.build_flags} -DHW_0_11_X -DENABLE_SOUND_MODULE
+
+[env:0_11_X_WT901]
+build_src_filter = ${env.build_src_filter} +<imu/WT901_I2C/> +<soundsystem.cpp>
+lib_ignore = JY901_SERIAL
+lib_deps = ${env.lib_deps}
+           https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
+           JY901_I2C
+build_flags = ${env.build_flags} -DWT901_I2C -DHW_0_11_X -DENABLE_SOUND_MODULE
 
 
 [env:0_10_X_MPU9250]
 lib_ignore = JY901_SERIAL,JY901_I2C
-lib_deps = ${env.lib_deps} 
-    bolderflight/Bolder Flight Systems MPU9250@^1.0.2
-    https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
+lib_deps = ${env.lib_deps}
+           bolderflight/Bolder Flight Systems MPU9250@^1.0.2
+           https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
 build_src_filter = ${env.build_src_filter} +<imu/MPU9250/> +<soundsystem.cpp>
 build_flags = ${env.build_flags} -DHW_0_10_X -DENABLE_SOUND_MODULE
 
 [env:0_10_X_WT901]
 build_src_filter = ${env.build_src_filter} +<imu/WT901_I2C/> +<soundsystem.cpp>
 lib_ignore = JY901_SERIAL
-lib_deps = ${env.lib_deps} 
-    https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
-    JY901_I2C
-build_flags =
-    ${env.build_flags} -DWT901_I2C -DHW_0_10_X -DENABLE_SOUND_MODULE
+lib_deps = ${env.lib_deps}
+           https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
+           JY901_I2C
+build_flags = ${env.build_flags} -DWT901_I2C -DHW_0_10_X -DENABLE_SOUND_MODULE
 
 [env:0_9_X_MPU9250]
 lib_ignore = JY901_SERIAL,JY901_I2C
-lib_deps = ${env.lib_deps} 
-    bolderflight/Bolder Flight Systems MPU9250@^1.0.2
-    https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
+lib_deps = ${env.lib_deps}
+           bolderflight/Bolder Flight Systems MPU9250@^1.0.2
+           https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
 build_src_filter = ${env.build_src_filter} +<imu/MPU9250/> +<soundsystem.cpp>
 build_flags = ${env.build_flags} -DHW_0_9_X -DENABLE_SOUND_MODULE
 
 [env:0_9_X_WT901_INSTEAD_OF_SOUND]
 lib_ignore = JY901_I2C
 build_src_filter = ${env.build_src_filter} +<imu/WT901_SERIAL/>
-lib_deps = ${env.lib_deps} 
-    JY901_SERIAL
-build_flags =
-    ${env.build_flags} -DWT901_INSTEAD_OF_SOUND -DHW_0_9_X
+lib_deps = ${env.lib_deps}
+           JY901_SERIAL
+build_flags = ${env.build_flags} -DWT901_INSTEAD_OF_SOUND -DHW_0_9_X
 
 [env:0_9_X_WT901]
 lib_ignore = JY901_I2C
 build_src_filter = ${env.build_src_filter} +<imu/WT901_SERIAL/> +<soundsystem.cpp>
-lib_deps = ${env.lib_deps} 
-    JY901_SERIAL
-    https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
-build_flags =
-    ${env.build_flags} -DWT901 -DHW_0_9_X -DENABLE_SOUND_MODULE
+lib_deps = ${env.lib_deps}
+           JY901_SERIAL
+           https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
+build_flags = ${env.build_flags} -DWT901 -DHW_0_9_X -DENABLE_SOUND_MODULE

--- a/Firmware/LowLevel/platformio.ini
+++ b/Firmware/LowLevel/platformio.ini
@@ -15,6 +15,8 @@ default_src_filter = +<*>
 
 [env]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+platform_packages =
+	maxgerhardt/framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git
 board = pico
 framework = arduino
 board_build.core = earlephilhower
@@ -49,7 +51,7 @@ build_src_filter = +<*> -<.git/> -<.svn/> -<imu/*> -<soundsystem.cpp>
 lib_ignore = JY901_SERIAL,JY901_I2C
 lib_deps = ${env.lib_deps} 
     bolderflight/Bolder Flight Systems MPU9250@^1.0.2
-    powerbroker2/DFPlayerMini_Fast@^1.2.4
+    https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
 build_src_filter = ${env.build_src_filter} +<imu/MPU9250/> +<soundsystem.cpp>
 build_flags = ${env.build_flags} -DHW_0_10_X -DENABLE_SOUND_MODULE
 
@@ -57,7 +59,7 @@ build_flags = ${env.build_flags} -DHW_0_10_X -DENABLE_SOUND_MODULE
 build_src_filter = ${env.build_src_filter} +<imu/WT901_I2C/> +<soundsystem.cpp>
 lib_ignore = JY901_SERIAL
 lib_deps = ${env.lib_deps} 
-    powerbroker2/DFPlayerMini_Fast@^1.2.4
+    https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
     JY901_I2C
 build_flags =
     ${env.build_flags} -DWT901_I2C -DHW_0_10_X -DENABLE_SOUND_MODULE
@@ -66,7 +68,7 @@ build_flags =
 lib_ignore = JY901_SERIAL,JY901_I2C
 lib_deps = ${env.lib_deps} 
     bolderflight/Bolder Flight Systems MPU9250@^1.0.2
-    powerbroker2/DFPlayerMini_Fast@^1.2.4
+    https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
 build_src_filter = ${env.build_src_filter} +<imu/MPU9250/> +<soundsystem.cpp>
 build_flags = ${env.build_flags} -DHW_0_9_X -DENABLE_SOUND_MODULE
 
@@ -83,6 +85,6 @@ lib_ignore = JY901_I2C
 build_src_filter = ${env.build_src_filter} +<imu/WT901_SERIAL/> +<soundsystem.cpp>
 lib_deps = ${env.lib_deps} 
     JY901_SERIAL
-    powerbroker2/DFPlayerMini_Fast@^1.2.4	
+    https://github.com/Makuna/DFMiniMp3.git#13baf94 ; TODO: Switch to related version once commit 13baf94 (required PIO patch) got versioned 
 build_flags =
     ${env.build_flags} -DWT901 -DHW_0_9_X -DENABLE_SOUND_MODULE

--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -18,12 +18,12 @@
 #include <Arduino.h>
 #include <FastCRC.h>
 #include <PacketSerial.h>
+#include "debug.h"
 #include "datatypes.h"
 #include "pins.h"
 #include "ui_board.h"
 #include "imu.h"
 #ifdef ENABLE_SOUND_MODULE
-#include <DFPlayerMini_Fast.h>
 #include <soundsystem.h>
 #endif
 
@@ -34,14 +34,6 @@
 #define LIFT_EMERGENCY_MILLIS 500  // Time for wheels to be lifted in order to count as emergency. This is to filter uneven ground.
 #define BUTTON_EMERGENCY_MILLIS 20 // Time for button emergency to activate. This is to debounce the button if triggered on bumpy surfaces
 
-// Define to stream debugging messages via USB
-// #define USB_DEBUG
-
-// Only define DEBUG_SERIAL if USB_DEBUG is actually enabled.
-// This enforces compile errors if it's used incorrectly.
-#ifdef USB_DEBUG
-#define DEBUG_SERIAL Serial
-#endif
 #define PACKET_SERIAL Serial1
 
 SerialPIO uiSerial(PIN_UI_TX, PIN_UI_RX, 250);
@@ -78,7 +70,7 @@ PacketSerial UISerial;     // COBS communication PICO UI-Board
 FastCRC16 CRC16;
 
 #ifdef ENABLE_SOUND_MODULE
-MP3Sound my_sound; // Soundsystem
+MP3Sound *my_sound = MP3Sound::GetInstance(); // Soundsystem
 #endif
 
 unsigned long last_imu_millis = 0;
@@ -467,12 +459,12 @@ void setup()
 #ifdef ENABLE_SOUND_MODULE
   p.neoPixelSetValue(0, 0, 255, 255, true);
 
-  sound_available = my_sound.begin();
+  sound_available = my_sound->begin();
   if (sound_available)
   {
     p.neoPixelSetValue(0, 0, 0, 255, true);
-    my_sound.setvolume(100);
-    my_sound.playSoundAdHoc(1);
+    my_sound->setVolume(100);
+    my_sound->playSoundAdHoc(1);
     p.neoPixelSetValue(0, 255, 255, 0, true);
   }
   else
@@ -701,7 +693,7 @@ void loop()
 #ifdef ENABLE_SOUND_MODULE
     if (sound_available)
     {
-      my_sound.processSounds();
+      my_sound->processSounds();
     }
 #endif
   }

--- a/Firmware/LowLevel/src/soundsystem.cpp
+++ b/Firmware/LowLevel/src/soundsystem.cpp
@@ -14,93 +14,149 @@
 // SOFTWARE.
 //
 
-#include <soundsystem.h>
+/*                      | Original      |        Old clones          |        Newer clones    | Unknown
+ * DFPlayer Chip        | DFROBOT LISP3 | YX5200-24SS | MH2024K-24SS | MH2024K-16SS | GD3200B | YX6200-16S
+ * -------------------------------------------------------------------------------------------------------
+ * Tested               |      ok       |             |     ok       |              |   ok    |
+ * Throws initial 0x3   |      no       |             |    120ms     |              |   yes   |
+ * Autoplay files *1    |      yes      |             |              |              |   no    |
+ * Reset->isOnline *2   |     902ms     |             |    901ms     |              |  602ms  |
+ * playGlobalTrack()    |      yes      |             |     NO       |              |   yes   |
+ * -------------------------------------------------------------------------------------------------------
+ * *1 = Autoplays (unasked) all (at least) root files = Output spam
+ * *2 = Highly depends on SD-Card and content
+ *
+ */
 
+#include <Arduino.h>
+#include "debug.h"
+#include "pins.h"
+#include "soundsystem.h"
 
 SerialPIO soundSerial(PIN_SOUND_TX, PIN_SOUND_RX, 250);
 
-DFPlayerMini_Fast myMP3;
+DfMp3 myMP3(soundSerial);
 
+MP3Sound *MP3Sound::mp3sound_ = nullptr;
 
 MP3Sound::MP3Sound()
 {
-
-    this->anzSoundfiles =   0;          // number of files stored on the SD-card
-    this->playing =         false;
+    this->anzSoundfiles = 0; // number of files stored on the SD-card
+    this->playing = false;
     this->sound_available = false;
-
 }
 
-
-
 bool MP3Sound::begin()
-              
 {
+    myMP3.begin();
 
-    // serial stream init for soundmodule
-    soundSerial.begin(9600);
-    soundSerial.flush();
-    while (soundSerial.available())
-        soundSerial.read();
-    // init soundmodule
-    sound_available = myMP3.begin(soundSerial,true);    
-    this->anzSoundfiles = myMP3.numSdTracks();
+    // DFPlayer clone chips seem to send an 0x03 (comm error) message once ready to receive commands.
+    // Let's use it here to identify when they're ready to receive commands.
+    // For sure this is extra penalty of approx. 200ms for the original chip.
+    // FIXME: Should we make it optional i.e. with a '#define DFPLAYER_CLONE' switch?
+    uint32_t start_ms = millis();
+    while (!received_clone_init_error && millis() < start_ms + DFP_CLONE_ERROR_TIMEOUT)
+    {
+        delay(20);
+        myMP3.loop();
+    }
+    DEBUG_PRINT("DFPlayer-Clone init error delay (");
+    DEBUG_PRINT_VAL(millis() - start_ms, DEC);
+    DEBUG_PRINTLN("ms)");
+
+    // Some DFPlayer chips better get a reset cmd for a defined 'ready' state, which is more precise than some kind of static (and large) 'delay(3000)'
+    DEBUG_PRINTLN("Reset DFPlayer...");
+    myMP3.reset();
+    start_ms = millis();
+    while (!myMP3.isOnline())
+    {
+        delay(50);
+        myMP3.loop();
+        if (millis() >= start_ms + DFP_ONLINE_TIMEOUT)
+        {
+            DEBUG_PRINTLN("DFPlayer timed out!");
+            return false;
+        }
+    }
+    DEBUG_PRINT("DFPlayer online (");
+    DEBUG_PRINT_VAL(millis() - start_ms, DEC);
+    DEBUG_PRINTLN("ms)");
+
+    this->anzSoundfiles = myMP3.getTotalTrackCount(DfMp3_PlaySource_Sd);
+    DEBUG_PRINT_VAL(this->anzSoundfiles, DEC);
+    DEBUG_PRINTLN(" sound files");
     return this->anzSoundfiles > 0;
 }
 
-
-void MP3Sound::setvolume(int vol)  // scales from 0 to 100 %
+void MP3Sound::setVolume(uint8_t vol) // scales from 0 to 100 %
 {
-
-     // value of 30 is max equivalent to 100 %
-     int val = (int) (30.0 / 100.0 * (double)vol);  
-     myMP3.volume(val);
-     delay(300);
-
+    // value of 30 is max equivalent to 100 %
+    uint8_t val = (uint8_t)(30.0 / 100.0 * (double)vol);
+    DEBUG_PRINT("Set volume ");
+    DEBUG_PRINTLN_VAL(val, DEC);
+    myMP3.setVolume(val);
 }
-
-
 
 void MP3Sound::playSoundAdHoc(int soundNr)
 {
-    if(soundNr > anzSoundfiles) return;
+    if (soundNr > anzSoundfiles)
+        return;
 
-    myMP3.play(soundNr);    
+    myMP3.playGlobalTrack(soundNr);
 }
-
-
-
 
 void MP3Sound::playSound(int soundNr)
 {
-    if((soundNr > anzSoundfiles)  || (active_sounds.size() == BUFFERSIZE) ) return;
+    if ((soundNr > anzSoundfiles) || (active_sounds.size() == BUFFERSIZE))
+        return;
 
     active_sounds.push_front(soundNr);
-    
 }
-
 
 int MP3Sound::sounds2play()
 {
 
-
-   return active_sounds.size();
-
-
+    return active_sounds.size();
 }
-
-
 
 int MP3Sound::processSounds()
 {
-   int n = active_sounds.size(); 
-   if (n == 0) return(n);
-   if (myMP3.isPlaying()) return(n);
-   
-   int file2play = active_sounds.back();
-   myMP3.play(file2play);
-   active_sounds.pop_back();
+    int n = active_sounds.size();
+    if (n == 0)
+        return (n);
+    //    if (myMP3.isPlaying())
+    //        return (n);
 
-   return active_sounds.size();
+    int file2play = active_sounds.back();
+    //    myMP3.play(file2play);
+    active_sounds.pop_back();
 
+    return active_sounds.size();
+}
+
+void MP3Sound::OnError(DfMp3 &mp3, uint16_t errorCode)
+{
+#ifdef USB_DEBUG
+    DEBUG_SERIAL.print("DFPlayer error: 0x");
+    DEBUG_SERIAL.println(errorCode, HEX);
+#endif
+
+    MP3Sound *snd = MP3Sound::GetInstance();
+    if (!snd->reset_sent)
+    {
+        snd->received_clone_init_error = true;
+    }
+}
+
+MP3Sound *MP3Sound::GetInstance()
+{
+    /**
+     * This is a safer way to create an instance. instance = new Singleton is
+     * dangeruous in case two instance threads wants to access at the same time
+     */
+    if (mp3sound_ == nullptr)
+    {
+        mp3sound_ = new MP3Sound();
+    }
+    return mp3sound_;
 }


### PR DESCRIPTION
Hi Clemens!

Because it took me 4 orders to get an original (working) DFPlayer module, I did some evaluation in the different DFPlayer modules (and their chip-clones).

As far as I could evaluate, [Makuna's DFMiniMp3 lib](https://github.com/Makuna/DFMiniMp3) has the best support, also for the clones you'll get (always) if you don't order by DFRobot.

If you've some time, please to a look to this lib switch. It works at least with my orginial DFRobot as well with the GD3200B chip. I also tested with the widely published MH2024K-24SS which also looks promising, but didn't work with this PR due to another issue (insufficient "global track" = "soundfiles in root" support)!

Even if Makuna's DFMiniMp3 lib has a larger support for DFPlayer clones,
it has the drawback of his 'ugly' (my personally opinion) static implemented notification methods,
which make it impossible (for me) to call instance methods/vars from the static notification methods.
I didn't found a better way than making your soundsystem a singleton class (instead of over-engineere it with an observer pattern, as I guessed it will be the only sound on OM ;-)).

Please take a look and drop me your opinion.

I guess, it's one of your lessest interesting topics for you, but further on, I would like/offer to switch the sound system in that way that we're capable to play a background sound (i.e. for bootstrap, undocking, ...) while your current sounds could be played as "advert" sounds (DFPlayer manner) (interrupting the background sound).
But for this it would be required to restructure the soundfiles on the SD-Card in "mp3" and "advert" folders.
How do you think about such a change?