### PR TITLE
Fix sound busy bit

### DIFF
--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -314,9 +314,9 @@ void loop1() {
             case 6:
                 mutex_enter_blocking(&mtx_status_message);
                 if (state) {
-                    status_message.status_bitmask |= 0b00100000;
+                    status_message.status_bitmask |= 0b01000000;
                 } else {
-                    status_message.status_bitmask &= 0b11011111;
+                    status_message.status_bitmask &= 0b10111111;
                 }
                 mutex_exit(&mtx_status_message);
                 break;


### PR DESCRIPTION
Busy line of sound module has set wrong Bit 5 (Sound available) according to this definition

```
struct ll_status {
    // Type of this message. Has to be PACKET_ID_LL_STATUS.
    uint8_t type;
    // Bitmask for rain, sound, powers etc
    // Bit 0: Initialized (i.e. setup() was a success). If this is 0, all other bits are meaningless.
    // Bit 1: Raspberry Power
    // Bit 2: Charging enabled
    // Bit 3: don't care
    // Bit 4: Rain detected
    // Bit 5: Sound available
    // Bit 6: Sound busy
    // Bit 7: UI Board available
    uint8_t status_bitmask;
    ...
```

Fixed now to Bit 6