### PR TITLE
Initialize PIN_ENABLE_CHARGE pin to HIGH to reset BMS undervoltage

### DIFF
--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -372,7 +372,7 @@ void setup() {
     // Setup pins
     pinMode(LED_BUILTIN, OUTPUT);
     pinMode(PIN_ENABLE_CHARGE, OUTPUT);
-    digitalWrite(PIN_ENABLE_CHARGE, LOW);
+    digitalWrite(PIN_ENABLE_CHARGE, HIGH);
 
     gpio_init(PIN_RASPI_POWER);
     gpio_put(PIN_RASPI_POWER, true);


### PR DESCRIPTION
Provides a simple method to reset BMS undervoltage protection:
Switch off main power switch with mower out of dock.
Place mower in dock.
Switch on main power switch.

Should be pretty safe to do this, checkShouldCharge will be run immediately and disable charging if any of the values are off.