### PR TITLE
Improve ADC accuracy

### DIFF
--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -694,7 +694,11 @@ void loop() {
 
 
         // If mowing use charge current ADC to determine adc offset
-        if( last_high_level_state.current_mode == HighLevelMode::MODE_AUTONOMOUS && last_high_level_state.gps_quality != 0 ) {
+        if(
+                ROS_running &&
+                last_high_level_state.current_mode == HighLevelMode::MODE_AUTONOMOUS &&
+                last_high_level_state.gps_quality != 0
+            ) {
             adc_offset_samples[next_adc_offset_sample++] = (float)analogRead(PIN_ANALOG_CHARGE_VOLTAGE);
             next_adc_offset_sample %= 20;
 

--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -62,6 +62,10 @@ SerialPIO uiSerial(PIN_UI_TX, PIN_UI_RX, 250);
 #define R_SHUNT 0.003f
 #define CURRENT_SENSE_GAIN 100.0f
 
+int next_adc_offset_sample = 0;
+float adc_offset_samples[20] = {0};
+float adc_offset = 0.0f;
+
 #define BATT_ABS_MAX 28.7f
 #define BATT_ABS_Min 21.7f
 
@@ -677,15 +681,28 @@ void loop() {
         updateNeopixel();
 
         status_message.v_battery =
-                (float) analogRead(PIN_ANALOG_BATTERY_VOLTAGE) * (3.3f / 4096.0f) * ((VIN_R1 + VIN_R2) / VIN_R2);
-        status_message.v_charge =
-                (float) analogRead(PIN_ANALOG_CHARGE_VOLTAGE) * (3.3f / 4096.0f) * ((VIN_R1 + VIN_R2) / VIN_R2);
+            ((float)analogRead(PIN_ANALOG_BATTERY_VOLTAGE) - adc_offset) * (3.33f / 4096.0f) * ((VIN_R1 + VIN_R2) / VIN_R2);
 #ifndef IGNORE_CHARGING_CURRENT
         status_message.charging_current =
-                (float) analogRead(PIN_ANALOG_CHARGE_CURRENT) * (3.3f / 4096.0f) / (CURRENT_SENSE_GAIN * R_SHUNT);
+            ((float)analogRead(PIN_ANALOG_CHARGE_CURRENT) - adc_offset) * (3.33f / 4096.0f) / (CURRENT_SENSE_GAIN * R_SHUNT);
 #else
         status_message.charging_current = -1.0f;
 #endif
+        status_message.v_charge = ((float)analogRead(PIN_ANALOG_CHARGE_VOLTAGE) - adc_offset) * (3.33f / 4096.0f) * ((VIN_R1 + VIN_R2) / VIN_R2);
+
+
+        // If mowing use charge current ADC to determine adc offset
+        if( last_high_level_state.current_mode == HighLevelMode::MODE_AUTONOMOUS && last_high_level_state.gps_quality != 0 ) {
+            adc_offset_samples[next_adc_offset_sample++] = (float)analogRead(PIN_ANALOG_CHARGE_VOLTAGE);
+            next_adc_offset_sample %= 20;
+
+            float tmp = 0.0f;
+            for(int i=0; i<20; i++) {
+                tmp += adc_offset_samples[i];
+            }
+            adc_offset = tmp / 20.0f;
+        }
+
         status_message.status_bitmask = (status_message.status_bitmask & 0b11111011) | ((charging_allowed & 0b1) << 2);
         status_message.status_bitmask = (status_message.status_bitmask & 0b11011111) | ((sound_available & 0b1) << 5);
 

--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -65,6 +65,8 @@ SerialPIO uiSerial(PIN_UI_TX, PIN_UI_RX, 250);
 int next_adc_offset_sample = 0;
 float adc_offset_samples[20] = {0};
 float adc_offset = 0.0f;
+// Limit adc_offset to 3%
+#define MAX_ADC_OFFSET_PC 0.03f
 
 #define BATT_ABS_MAX 28.7f
 #define BATT_ABS_Min 21.7f
@@ -700,7 +702,13 @@ void loop() {
             for(int i=0; i<20; i++) {
                 tmp += adc_offset_samples[i];
             }
-            adc_offset = tmp / 20.0f;
+            float new_adc_offset = tmp / 20.0f;
+            // Limit maximum offset
+            if(new_adc_offset > 0.0f) {
+                adc_offset = min(new_adc_offset, (4096 * MAX_ADC_OFFSET_PC));
+            } else {
+                adc_offset = max(new_adc_offset, -(4096 * MAX_ADC_OFFSET_PC));
+            }
         }
 
         status_message.status_bitmask = (status_message.status_bitmask & 0b11111011) | ((charging_allowed & 0b1) << 2);


### PR DESCRIPTION
Use the charge current ADC when undocked to determine ADC offset, tweak the resistors values, and disable SMPS powersaving during ADC.

With this I get v_battery pretty close to the measured value