### PR TITLE
Feature/support uiboard available flag

### DIFF
--- a/Firmware/LowLevel/src/datatypes.h
+++ b/Firmware/LowLevel/src/datatypes.h
@@ -32,6 +32,8 @@ enum HighLevelMode {
     MODE_RECORDING = 3 // ROS connected, Manual mode during recording etc
 };
 
+#define LL_STATUS_BIT_UI_AVAIL 0b10000000
+
 #pragma pack(push, 1)
 struct ll_status {
     // Type of this message. Has to be PACKET_ID_LL_STATUS.

--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -489,26 +489,27 @@ void onUIPacketReceived(const uint8_t *buffer, size_t size) {
         ui_version = msg->version;
         status_message.status_bitmask |= LL_STATUS_BIT_UI_AVAIL;
         ui_get_version_respond_timeout = 0;
-    } else if (buffer[0] == Get_Button && size == sizeof(struct msg_event_button))
-        {
-            struct msg_event_button *msg = (struct msg_event_button *)buffer;
-            struct ll_ui_event ui_event;
-            ui_event.type = PACKET_ID_LL_UI_EVENT;
-            ui_event.button_id = msg->button_id;
-            ui_event.press_duration = msg->press_duration;
-            sendMessage(&ui_event, sizeof(ui_event));
-        }
-        else if (buffer[0] == Get_Emergency && size == sizeof(struct msg_event_emergency))
-        {
-            struct msg_event_emergency *msg = (struct msg_event_emergency *)buffer;
-            stock_ui_emergency_state = msg->state;
-        }
-        else if (buffer[0] == Get_Rain && size == sizeof(struct msg_event_rain))
-        {
-            struct msg_event_rain *msg = (struct msg_event_rain *)buffer;
-            stock_ui_rain = (msg->value < msg->threshold);
-        }
     }
+    else if (buffer[0] == Get_Button && size == sizeof(struct msg_event_button))
+    {
+        struct msg_event_button *msg = (struct msg_event_button *)buffer;
+        struct ll_ui_event ui_event;
+        ui_event.type = PACKET_ID_LL_UI_EVENT;
+        ui_event.button_id = msg->button_id;
+        ui_event.press_duration = msg->press_duration;
+        sendMessage(&ui_event, sizeof(ui_event));
+    }
+    else if (buffer[0] == Get_Emergency && size == sizeof(struct msg_event_emergency))
+    {
+        struct msg_event_emergency *msg = (struct msg_event_emergency *)buffer;
+        stock_ui_emergency_state = msg->state;
+    }
+    else if (buffer[0] == Get_Rain && size == sizeof(struct msg_event_rain))
+    {
+        struct msg_event_rain *msg = (struct msg_event_rain *)buffer;
+        stock_ui_rain = (msg->value < msg->threshold);
+    }
+}
 
 void onPacketReceived(const uint8_t *buffer, size_t size) {
     // sanity check for CRC to work (1 type, 1 data, 2 CRC)


### PR DESCRIPTION
Support `status_message.status_bitmask` (`ui_board_available` mower/status) flag by:
- Sending a UI- Get_Version request every 5 seconds
- If a UI- Get_Version response happen within 100ms, `status_message.status_bitmask` bit 7 (UI available) get set. If 100ms time out, it get cleared

In addition UI- Get_version->version response get stored in global `ui_version` var.
Like to have it for a future PR where we might handle dump LED-/Button-Boards differently than more intelligent CoverUI's with a display ;-)

Please drop me a note if you're unhappy with anything ;-)