### PR TITLE
Better support for CoverUI's "with Display" Proposal

### DIFF
--- a/Firmware/LowLevel/src/ui_board.h
+++ b/Firmware/LowLevel/src/ui_board.h
@@ -27,9 +27,9 @@ enum TYPE
     Set_LEDs = 0xB2,
     Get_Button = 0xB3,
     Get_Emergency = 0xB4, // Stock-CoverUI
-    Get_Rain = 0xB5       // Stock-CoverUI
+    Get_Rain = 0xB5,      // Stock-CoverUI
+    Get_Subscribe = 0xB6
 };
-
 
 // Function definiton for the 18 LEDS
 enum LED_id
@@ -69,6 +69,13 @@ enum Emergency_state
     Emergency_stop2 = 0b00100,
     Emergency_lift1 = 0b01000,
     Emergency_lift2 = 0b10000
+};
+
+enum Topic_state
+{
+    Topic_set_leds      = 1 << 0,
+    Topic_set_ll_status = 1 << 1,
+    Topic_set_hl_state  = 1 << 2,
 };
 
 #pragma pack(push, 1)
@@ -145,6 +152,18 @@ struct msg_event_emergency
     uint8_t type;  // Command type
     uint8_t state; // Same as in ll_status.emergency_bitmask of datatypes.h
     uint16_t crc;  // CRC 16
+} __attribute__((packed));
+#pragma pack(pop)
+
+// Cover UI might subscribe in what data it's interested to receive
+
+#pragma pack(push, 1)
+struct msg_event_subscribe
+{
+    uint8_t type;          // Command type
+    uint8_t topic_bitmask; // Bitmask of data subscription(s), see Topic_state
+    uint16_t interval;     // Interval (ms) how often to send topic(s)
+    uint16_t crc;          // CRC 16
 } __attribute__((packed));
 #pragma pack(pop)
 


### PR DESCRIPTION
# Issue

When porting a stock CoverUI with some kind of display (instead of simple LEDs), it's currently required to translate the LED states (on, off, blink_slow, blink_fast) back to some kind a displayable value.
This is somehow cumbersome as well as inaccurate (i.e. charging state is currently represented by one LED).

Because updating the CoverUI is painful (you've to open the mower), it's required to find a solution which doesn't influence current implementations in any way.

# Approach

Implement some kind of request which has to be initiated by the CoverUI's FW which is interested in other data than the current Set_LEDs packet.

# Implementation

For this, I added the msg_event_subscribe packet, which can be requested by the CoverUI to "subscribe" to specific data. Default to Set_LEDs packet, so that current installations work as before.

# Summary

This is a proposal. Nothing tested yet.
Like to know you thoughts.
As I expect to get two more stock CoverUI's the next days, and one will have a display again, I like to find a solution which is clear and stable for some longer time.


