### PR TITLE
Store configuration in flash

### DIFF
--- a/Firmware/LowLevel/include/debug.h
+++ b/Firmware/LowLevel/include/debug.h
@@ -1,0 +1,47 @@
+// Created by Apehaenger on 02/02/23.
+//
+// This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//
+// Feel free to use the design in your private/educational projects, but don't try to sell the design or products based on it without getting my consent first.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//
+#ifndef _DEBUG_H_
+#define _DEBUG_H_
+
+// Define to stream debugging messages via USB
+#define USB_DEBUG
+#define DEBUG_PREFIX "" // You may define a debug prefix string
+
+#ifdef USB_DEBUG
+#define DEBUG_SERIAL Serial
+// #define DfMiniMp3Debug DEBUG_SERIAL // Also output DFPlayer IN/OUT cmd data
+
+// Some bloody simple debug macros which superfluous '#ifdef USB_DEBUG' ...
+#define DEBUG_BEGIN(b)     \
+    DEBUG_SERIAL.begin(b); \
+    while (!DEBUG_SERIAL)  \
+        ;
+#define DEBUG_PRINTF(fmt, ...)                                \
+    do                                                        \
+    {                                                         \
+        DEBUG_SERIAL.printf(DEBUG_PREFIX fmt, ##__VA_ARGS__); \
+    } while (0)
+#else
+#define DEBUG_BEGIN(b)
+#define DEBUG_PRINTF(fmt, ...)
+#endif
+
+#define PRINTF_BINARY_PATTERN_INT8 "%c%c%c%c%c%c%c%c"
+#define PRINTF_BYTE_TO_BINARY_INT8(i)                                                                               \
+    (((i)&0x80ll) ? '1' : '0'), (((i)&0x40ll) ? '1' : '0'), (((i)&0x20ll) ? '1' : '0'), (((i)&0x10ll) ? '1' : '0'), \
+        (((i)&0x08ll) ? '1' : '0'), (((i)&0x04ll) ? '1' : '0'), (((i)&0x02ll) ? '1' : '0'), (((i)&0x01ll) ? '1' : '0')
+
+#endif // _DEBUG_H_

--- a/Firmware/LowLevel/include/nv_config.h
+++ b/Firmware/LowLevel/include/nv_config.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Jörg Ebeling (Apehaenger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.* Testing/examples for reading/writing flash on the RP2040.
+ *
+ * Heavily copied from as well as must-read:
+ * https://github.com/MakerMatrix/RP2040_flash_programming
+ */
+
+#include <Arduino.h>
+
+// #define NV_CONFIG_MAX_SAVE_INTERVAL 300000 // Don't save more often than every 5 minutes
+#define NV_CONFIG_MAX_SAVE_INTERVAL 10000 // DBG: Don't save more often than every 10 seconds
+
+#define LL_CONFIG_BIT_HL_CONFIG_RECEIVED 0x1
+#define LL_CONFIG_BIT_DFPIS5V 0x2
+
+namespace nv_config
+{
+#pragma pack(push, 1)
+    // Config struct with reasonable defaults
+    struct Config
+    {
+        // Config bitmask:
+        // Bit 0: ROS config packet received. See LL_CONFIG_BIT_HL_CONFIG_RECEIVED
+        // Bit 1: DFP is 5V (enable full sound). See LL_CONFIG_BIT_DFPIS5V
+        uint8_t config_bitmask;
+        uint8_t language = 0;          // Sound language index 0 = Folder "01" = English(US), 1 = Folder "49" = German
+        uint8_t volume = 100;          // Sound loudness from 0 to 100 %
+        uint8_t reserved;              // padding
+        uint32_t rain_threshold = 700; // If (stock CoverUI) rain value < rain_threshold then it rains. Expected to differ between C500, SA and SC types
+        /* FIXME: Can't see a benefit why a CRC16 within our struct, for the initial config set will ensure anything ;-)
+        uint16_t nv_crc;               // CRC 16 used to validate what?*/
+
+        /* Possible future config settings
+        uint16_t free;                 // Future config setting
+        uint16_t free_n;               // Future config setting
+        uint16_t crc_n;                // Future config CRC16 for detection if loaded (old) config already has the new config member */
+    } __attribute__((packed));
+#pragma pack(pop)
+
+    Config *get(); // Return a pointer to nv_config::config which holds the last saved config, or the first default one. Config member are writable, see save()
+    void save();   // Handle a possibly changed nv_config::config member and save it to flash, but only within a defined timeout to ensure wear level protection
+}

--- a/Firmware/LowLevel/include/nv_config.h
+++ b/Firmware/LowLevel/include/nv_config.h
@@ -19,42 +19,57 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.* Testing/examples for reading/writing flash on the RP2040.
  *
- * Heavily copied from as well as must-read:
+ * Heavily inspired, copied from, as well as must-read:
  * https://github.com/MakerMatrix/RP2040_flash_programming
  */
 
 #include <Arduino.h>
 
-// #define NV_CONFIG_MAX_SAVE_INTERVAL 300000 // Don't save more often than every 5 minutes
-#define NV_CONFIG_MAX_SAVE_INTERVAL 10000 // DBG: Don't save more often than every 10 seconds
+// #define NV_CONFIG_MAX_SAVE_INTERVAL 60000UL // Don't save more often than once every 1 minute(s)
+#define NV_CONFIG_MAX_SAVE_INTERVAL 2000UL // DBG: Don't save more often than once every 1 second(s)
 
-#define LL_CONFIG_BIT_HL_CONFIG_RECEIVED 0x1
-#define LL_CONFIG_BIT_DFPIS5V 0x2
+// config_bitmask
+#define LL_CONFIG_BIT_HL_CONFIG_RECEIVED 0x1 // ROS config packet received
+#define LL_CONFIG_BIT_DFPIS5V 0x2            // DFP is set to 5V
+
+#define NV_RECORD_ID 0x4F4D4331                  // Record struct identifier "OMC1" for future flexible length Record.config
+#define NV_RECORD_ALIGNMENT (_Alignof(uint32_t)) // Ptr alignment of Record.id for quick in memory access
 
 namespace nv_config
 {
 #pragma pack(push, 1)
-    // Config struct with reasonable defaults
+    // Config struct example with reasonable defaults.
+    // This is where our application values should go.
+    // It's possible to extended it, but any extension should add an extension related CRC so that an old/last stored Record.config isn't lost.
+    //    (a new extension-crc isn't valid with a old Record.config. Thus the new extension values may get set i.e. with default values)
     struct Config
     {
         // Config bitmask:
         // Bit 0: ROS config packet received. See LL_CONFIG_BIT_HL_CONFIG_RECEIVED
         // Bit 1: DFP is 5V (enable full sound). See LL_CONFIG_BIT_DFPIS5V
-        uint8_t config_bitmask;
+        uint8_t config_bitmask = 0;
         uint8_t language = 0;          // Sound language index 0 = Folder "01" = English(US), 1 = Folder "49" = German
         uint8_t volume = 100;          // Sound loudness from 0 to 100 %
-        uint8_t reserved;              // padding
         uint32_t rain_threshold = 700; // If (stock CoverUI) rain value < rain_threshold then it rains. Expected to differ between C500, SA and SC types
-        /* FIXME: Can't see a benefit why a CRC16 within our struct, for the initial config set will ensure anything ;-)
-        uint16_t nv_crc;               // CRC 16 used to validate what?*/
 
         /* Possible future config settings
         uint16_t free;                 // Future config setting
         uint16_t free_n;               // Future config setting
-        uint16_t crc_n;                // Future config CRC16 for detection if loaded (old) config already has the new config member */
+        uint16_t crc_n;                // Future config CRC16 (for the new member) for detection if loaded (possibly old) config already has the new member */
+    } __attribute__((packed));
+
+    // Record(s) get placed sequentially into a flash page.
+    // The Record structure shouldn't get changed, because it would make old flash Record's unusable. Instead of, change Record.config
+    struct Record
+    {
+        const uint32_t id = NV_RECORD_ID; // Fixed record identifier, used to identify a possible Record within a flash page. If width get changed, change also NV_RECORD_ALIGNMENT
+        uint32_t num_sector_erase = 0;
+        uint32_t num_page_write = 0;
+        uint16_t crc; // Required to ensure that a found NV_RECORD_ID is really a Record
+        Config config;
     } __attribute__((packed));
 #pragma pack(pop)
 
-    Config *get(); // Return a pointer to nv_config::config which holds the last saved config, or the first default one. Config member are writable, see save()
-    void save();   // Handle a possibly changed nv_config::config member and save it to flash, but only within a defined timeout to ensure wear level protection
+    Config *get();             // Returned pointer hold the last saved Record.config, or the default one. Config member are writable, see delayedSaveChanges()
+    void delayedSaveChanges(); // Handle a possible changed nv_config::config member and save it to flash, but only within NV_CONFIG_MAX_SAVE_INTERVAL timeout for wear level protection
 }

--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -635,7 +635,7 @@ void loop() {
     imu_loop();
     updateChargingEnabled();
     updateEmergency();
-    nv_config::save();
+    nv_config::delayedSaveChanges();
 
     unsigned long now = millis();
 

--- a/Firmware/LowLevel/src/nv_config.cpp
+++ b/Firmware/LowLevel/src/nv_config.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024 Jörg Ebeling (Apehaenger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.* Testing/examples for reading/writing flash on the RP2040.
+ *
+ * Heavily copied from as well as must-read:
+ * https://github.com/MakerMatrix/RP2040_flash_programming
+ */
+#include "nv_config.h"
+#include "debug.h"
+#include <FastCRC.h>
+
+extern "C"
+{
+#include <hardware/sync.h>
+#include <hardware/flash.h>
+};
+
+// Set the target offset to the last sector of flash
+#define FLASH_TARGET_OFFSET (PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE)
+
+#ifdef DEBUG_PREFIX
+#undef DEBUG_PREFIX
+#define DEBUG_PREFIX "[NVC] "
+#endif
+
+namespace nv_config
+{
+    static_assert(sizeof(Config) <= FLASH_PAGE_SIZE, "Config struct size larger than page size"); // Probably doesn't harm, but didn't tested
+
+    int addr;
+    unsigned int page; // prevent comparison of unsigned and signed int
+    int first_empty_page = -1;
+
+    Config config; // Last or (if there hasn't been a config flashed before) default config
+    uint16_t crc;  // CRC of config
+
+    FastCRC16 CRC16;
+
+    unsigned long next_save_millis = millis() + NV_CONFIG_MAX_SAVE_INTERVAL;
+
+    Config *get()
+    {
+        DEBUG_PRINTF("FLASH_PAGE_SIZE: %d, FLASH_SECTOR_SIZE: %d, FLASH_BLOCK_SIZE: %d, PICO_FLASH_SIZE_BYTES: %d, XIP_BASE: 0x%x, FLASH_TARGET_OFFSET: %d\n",
+                     FLASH_PAGE_SIZE, FLASH_SECTOR_SIZE, FLASH_BLOCK_SIZE, PICO_FLASH_SIZE_BYTES, XIP_BASE,
+                     FLASH_TARGET_OFFSET);
+
+        // Read flash until first empty page found
+        for (page = 0; page < FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE; page++)
+        {
+            addr = XIP_BASE + FLASH_TARGET_OFFSET + (page * FLASH_PAGE_SIZE);
+            // p = (int *)addr;
+            Config *ptr = (Config *)addr;
+            // DEBUG_PRINTF("First four bytes of page %d (at 0x%x) = %d\n", page, int(p), *p);
+
+            // Instead of test all of our first Config member, lets cast the struct to a long long int, which has the same size than our struct,
+            // which make test for erased flash pages much easier
+            long long trix = *((long long *)ptr);
+            DEBUG_PRINTF("Config in page %d (at 0x%x) = config_bitmask: 0b" PRINTF_BINARY_PATTERN_INT8 ", rain_threshold: %d, language: %d, volume: %d, trix: %lld\n ",
+                         page, int(ptr), PRINTF_BYTE_TO_BINARY_INT8(ptr->config_bitmask), ptr->rain_threshold, ptr->language, ptr->volume, trix);
+            if (trix == -1)
+            {
+                first_empty_page = page;
+                DEBUG_PRINTF("First empty page is %d\n", first_empty_page);
+                break;
+            }
+        }
+
+        // Copy flash config if found
+        if (page > 0)
+        {
+            // Deep copy flash-config to our local one via implicit copy constructor
+            config = *(Config *)(XIP_BASE + FLASH_TARGET_OFFSET + ((page - 1) * FLASH_PAGE_SIZE));
+        }
+        DEBUG_PRINTF("Default or Last config's volume: %d\n", config.volume);
+
+        // CRC for simple checking if config has changed
+        crc = CRC16.ccitt((uint8_t *)&config, sizeof(Config));
+        DEBUG_PRINTF("Config CRC: 0x%x\n", crc);
+
+        return &config;
+    }
+
+    void save()
+    {
+        // Wear level protection
+        if (millis() < next_save_millis)
+            return;
+        next_save_millis = millis() + NV_CONFIG_MAX_SAVE_INTERVAL;
+
+        // Check CRC if config changed
+        uint16_t check_crc = CRC16.ccitt((uint8_t *)&config, sizeof(Config));
+        DEBUG_PRINTF("Actual- vs. stored- config CRC: 0x%x ?= 0x%x\n", check_crc, crc);
+        if (check_crc == crc)
+            return; // CRC doesn't changed
+
+        // If no empty page got found during get(), let's erase the flash
+        if (first_empty_page < 0)
+        {
+            DEBUG_PRINTF("Full sector, erase...\n");
+            uint32_t ints = save_and_disable_interrupts();
+            flash_range_erase(FLASH_TARGET_OFFSET, FLASH_SECTOR_SIZE);
+            first_empty_page = 0;
+            restore_interrupts(ints);
+        }
+
+        DEBUG_PRINTF("Write to page %d, volume %d...\n", first_empty_page, config.volume);
+        uint32_t ints = save_and_disable_interrupts();
+        flash_range_program(FLASH_TARGET_OFFSET + (first_empty_page * FLASH_PAGE_SIZE), (uint8_t *)&config, FLASH_PAGE_SIZE);
+        restore_interrupts(ints);
+        crc = check_crc;
+        first_empty_page++;
+        if (first_empty_page >= FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE)
+            first_empty_page = -1; // Last page written, indicated sector full
+    }
+}

--- a/Firmware/LowLevel/src/nv_config.cpp
+++ b/Firmware/LowLevel/src/nv_config.cpp
@@ -19,12 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.* Testing/examples for reading/writing flash on the RP2040.
  *
- * Heavily copied from as well as must-read:
+ * Heavily inspired, copied from, as well as must-read:
  * https://github.com/MakerMatrix/RP2040_flash_programming
  */
+#include <FastCRC.h>
+#include <memory>
 #include "nv_config.h"
 #include "debug.h"
-#include <FastCRC.h>
 
 extern "C"
 {
@@ -32,8 +33,10 @@ extern "C"
 #include <hardware/flash.h>
 };
 
-// Set the target offset to the last sector of flash
-#define FLASH_TARGET_OFFSET (PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE)
+#define FLASH_TARGET_OFFSET (PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE) // Target offset to the last sector of flash
+#define NV_MIN_RECORD_SIZE (sizeof(Record) - sizeof(Config))            // Minimum Record size (Record size without Config member)
+#define NV_PAGES_IN_SECTOR (FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE)        // How much pages fit into one sector
+#define NV_RECORD_CRC_DATALEN (sizeof(Record) - sizeof(Config) - sizeof(cur_record.crc))
 
 #ifdef DEBUG_PREFIX
 #undef DEBUG_PREFIX
@@ -42,12 +45,15 @@ extern "C"
 
 namespace nv_config
 {
-    static_assert(sizeof(Config) <= FLASH_PAGE_SIZE, "Config struct size larger than page size"); // Probably doesn't harm, but didn't tested
+    static_assert(sizeof(Record) <= FLASH_PAGE_SIZE, "Record struct size larger than page size");
 
-    int first_empty_page = -1;
+    int first_empty_page = -1; // First empty page in sector
+    int last_used_page = -1;   // Last used page with non-empty data
+    int last_record_pos = -1;  // Last record position within page (page_buf)
 
-    Config config; // Last or (if there hasn't been a config flashed before) default config
-    uint16_t crc;  // CRC of config
+    uint8_t page_buf[FLASH_PAGE_SIZE]; // Page buffer required for subsequential flash_range_program() of the same page
+    Record cur_record;                 // Current (last or (if there hasn't been a Record flashed before) default) Record
+    uint16_t config_crc;               // CRC of current Record->config used for config change detection
 
     FastCRC16 CRC16;
 
@@ -56,44 +62,72 @@ namespace nv_config
     Config *get()
     {
         DEBUG_PRINTF("FLASH_PAGE_SIZE: %d, FLASH_SECTOR_SIZE: %d, FLASH_BLOCK_SIZE: %d, PICO_FLASH_SIZE_BYTES: %d, XIP_BASE: 0x%x, FLASH_TARGET_OFFSET: %d\n",
-                     FLASH_PAGE_SIZE, FLASH_SECTOR_SIZE, FLASH_BLOCK_SIZE, PICO_FLASH_SIZE_BYTES, XIP_BASE,
-                     FLASH_TARGET_OFFSET);
+                     FLASH_PAGE_SIZE, FLASH_SECTOR_SIZE, FLASH_BLOCK_SIZE, PICO_FLASH_SIZE_BYTES, XIP_BASE, FLASH_TARGET_OFFSET);
+        DEBUG_PRINTF("NV_PAGES_IN_SECTOR: %d, sizeof(Record): %d, sizeof(Config): %d, possible num of records within one page: %d\n",
+                     NV_PAGES_IN_SECTOR, sizeof(Record), sizeof(Config), FLASH_PAGE_SIZE / sizeof(Record));
 
         // Read flash until first empty page found
-        unsigned int page; // prevent comparison of unsigned and signed int
+        int addr;
+        unsigned int page;
+        int32_t *p;
         for (page = 0; page < FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE; page++)
         {
-            int addr = XIP_BASE + FLASH_TARGET_OFFSET + (page * FLASH_PAGE_SIZE);
-            Config *ptr = (Config *)addr;
+            p = (int32_t *)(XIP_BASE + FLASH_TARGET_OFFSET + (page * FLASH_PAGE_SIZE));
 
-            // Instead testing all of our first config member, lets cast the struct to a long long int, which is save to identify an empty page
-            long long trix = *((long long *)ptr);
-            DEBUG_PRINTF("Config in page %d (at 0x%x) = config_bitmask: 0b" PRINTF_BINARY_PATTERN_INT8 ", rain_threshold: %d, language: %d, volume: %d, trix: %lld\n ",
-                         page, int(ptr), PRINTF_BYTE_TO_BINARY_INT8(ptr->config_bitmask), ptr->rain_threshold, ptr->language, ptr->volume, trix);
-            if (trix == -1)
+            // 0xFFFFFFFF cast as an int is -1 so this is how we detect an empty page
+            DEBUG_PRINTF("Page %d (0x%x): record_id = %ld (0x%lx)\n", page, int(p), *p, *p);
+            if (*p == -1 && first_empty_page < 0)
             {
                 first_empty_page = page;
-                DEBUG_PRINTF("First empty page is %d\n", first_empty_page);
+                break;
+            }
+            last_used_page = page;
+        }
+        DEBUG_PRINTF("last_used_page %d, first_empty_page %d\n", last_used_page, first_empty_page);
+
+        // Find last written Record
+        if (last_used_page >= 0)
+        {
+            // RLoop over last_used_page to find latest record via it's record.id
+            DEBUG_PRINTF("Last possible record (unaligned) = FLASH_PAGE_SIZE %d - NV_MIN_RECORD_SIZE %d = %u\n", FLASH_PAGE_SIZE, NV_MIN_RECORD_SIZE, FLASH_PAGE_SIZE - NV_MIN_RECORD_SIZE);
+            int addr = XIP_BASE + FLASH_TARGET_OFFSET + (last_used_page * FLASH_PAGE_SIZE);
+            // Calc last possible record offset without config, for the case that Record.config get changed, and pointer-align to "next multiple of"
+            int last_possible_record_offset = (FLASH_PAGE_SIZE - NV_MIN_RECORD_SIZE) - ((FLASH_PAGE_SIZE - NV_MIN_RECORD_SIZE) % NV_RECORD_ALIGNMENT) + NV_RECORD_ALIGNMENT;
+            DEBUG_PRINTF("last_possible_record_offset (aligned) 0x%x for Record.id alignment of %d\n", last_possible_record_offset, NV_RECORD_ALIGNMENT);
+            // Record test_record;
+            for (size_t i = last_possible_record_offset; i >= 0; i = i - NV_RECORD_ALIGNMENT)
+            {
+                uint32_t *p = (uint32_t *)(addr + i);
+                if (*p != NV_RECORD_ID)
+                    continue;
+
+                // Validate if the found NV_RECORD_ID is a valid Record.id
+                DEBUG_PRINTF("Page %d, offset 0x%x (at %p): Record.id prospect = 0x%lx\n", last_used_page, i, p, *p);
+                Record test_record;
+                memcpy(&test_record, (uint8_t *)p, sizeof(Record));
+                DEBUG_PRINTF("Test- Record: num_sector_erase: %ld, num_page_write: %ld, crc: 0x%lx\n", test_record.num_sector_erase, test_record.num_page_write, test_record.crc);
+                uint16_t test_crc = CRC16.ccitt((uint8_t *)&test_record, NV_RECORD_CRC_DATALEN);
+                DEBUG_PRINTF("Test- Record CRC 0x%x of datalen %d\n", test_crc, NV_RECORD_CRC_DATALEN);
+                if (test_crc != test_record.crc)
+                    continue;
+
+                DEBUG_PRINTF("Test- Record is valid. Buffer the full flash page\n");
+                memcpy(&page_buf, (uint8_t *)addr, FLASH_PAGE_SIZE);
+                memcpy(&cur_record, &test_record, sizeof(Record));
+                last_record_pos = i;
                 break;
             }
         }
-
-        // Copy flash config if found
-        if (page > 0)
-        {
-            // Deep copy flash-config to our local one via implicit copy constructor
-            config = *(Config *)(XIP_BASE + FLASH_TARGET_OFFSET + ((page - 1) * FLASH_PAGE_SIZE));
-        }
-        DEBUG_PRINTF("Default or Last config's volume: %d\n", config.volume);
+        DEBUG_PRINTF("Last (or default) config's volume: %d\n", cur_record.config.volume);
 
         // CRC for simple checking if config has changed
-        crc = CRC16.ccitt((uint8_t *)&config, sizeof(Config));
-        DEBUG_PRINTF("Config CRC: 0x%x\n", crc);
+        config_crc = CRC16.ccitt((uint8_t *)&cur_record.config, sizeof(Config));
+        DEBUG_PRINTF("cur_record.config CRC: 0x%x\n", config_crc);
 
-        return &config;
+        return &cur_record.config;
     }
 
-    void save()
+    void delayedSaveChanges()
     {
         // Wear level protection
         if (millis() < next_save_millis)
@@ -101,28 +135,55 @@ namespace nv_config
         next_save_millis = millis() + NV_CONFIG_MAX_SAVE_INTERVAL;
 
         // Check CRC if config changed
-        uint16_t check_crc = CRC16.ccitt((uint8_t *)&config, sizeof(Config));
-        DEBUG_PRINTF("Actual- vs. stored- config CRC: 0x%x ?= 0x%x\n", check_crc, crc);
-        if (check_crc == crc)
-            return; // CRC doesn't changed
+        uint16_t check_crc = CRC16.ccitt((uint8_t *)&cur_record.config, sizeof(Config));
+        DEBUG_PRINTF("Actual- vs. stored- config CRC: 0x%x ?= 0x%x\n", check_crc, config_crc);
+        if (check_crc == config_crc)
+            return; // Record.config doesn't changed
 
-        // If no empty page got found during get(), let's erase the flash
-        if (first_empty_page < 0)
+        // Prepare record position within page buffer
+        if (last_record_pos == -1)
+            last_record_pos = 0;
+        else
+        {
+            last_record_pos += sizeof(Record);
+            last_record_pos = last_record_pos - (last_record_pos % NV_RECORD_ALIGNMENT) + NV_RECORD_ALIGNMENT; // Adjust to "next multiple of" NV_RECORD_ALIGNMENT
+        }
+        if ((last_record_pos + sizeof(Record)) > FLASH_PAGE_SIZE)
+        {
+            // Will not fit anymore into the current page
+            last_used_page++;
+            last_record_pos = 0;
+            first_empty_page++;
+            std::fill_n(page_buf, FLASH_PAGE_SIZE, 0xff); // Mark page buffer as (flash) erased
+        }
+
+        // If no empty page got found during get(), or last page got eaten, let's erase the flash
+        if (first_empty_page < 0 || last_used_page >= NV_PAGES_IN_SECTOR)
         {
             DEBUG_PRINTF("Full sector, erase...\n");
             uint32_t ints = save_and_disable_interrupts();
             flash_range_erase(FLASH_TARGET_OFFSET, FLASH_SECTOR_SIZE);
-            first_empty_page = 0;
             restore_interrupts(ints);
+            // Reset positioning vars
+            last_used_page = 0;
+            first_empty_page = 0;
+            cur_record.num_sector_erase++;
+            std::fill_n(page_buf, FLASH_PAGE_SIZE, 0xff); // Mark page buffer as (flash) erased
         }
 
-        DEBUG_PRINTF("Write to page %d, volume %d...\n", first_empty_page, config.volume);
+        // Prepare record
+        cur_record.num_page_write++;
+        cur_record.crc = CRC16.ccitt((uint8_t *)&cur_record, NV_RECORD_CRC_DATALEN);
+        DEBUG_PRINTF("Record CRC 0x%x of datalen %d\n", cur_record.crc, NV_RECORD_CRC_DATALEN);
+
+        // memcopy cur_record to page buffer
+        memcpy(&page_buf[last_record_pos], &cur_record, sizeof(Record));
+
+        // Write page to flash
+        DEBUG_PRINTF("Write to page %d, with new record pos %d: volume %d...\n", last_used_page, last_record_pos, cur_record.config.volume);
         uint32_t ints = save_and_disable_interrupts();
-        flash_range_program(FLASH_TARGET_OFFSET + (first_empty_page * FLASH_PAGE_SIZE), (uint8_t *)&config, FLASH_PAGE_SIZE);
+        flash_range_program(FLASH_TARGET_OFFSET + (last_used_page * FLASH_PAGE_SIZE), (uint8_t *)page_buf, sizeof(page_buf));
         restore_interrupts(ints);
-        crc = check_crc;
-        first_empty_page++;
-        if (first_empty_page >= FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE)
-            first_empty_page = -1; // Last page written, indicated sector full
+        config_crc = check_crc; // Update last saved config CRC
     }
 }

--- a/Firmware/LowLevel/src/nv_config.cpp
+++ b/Firmware/LowLevel/src/nv_config.cpp
@@ -44,8 +44,6 @@ namespace nv_config
 {
     static_assert(sizeof(Config) <= FLASH_PAGE_SIZE, "Config struct size larger than page size"); // Probably doesn't harm, but didn't tested
 
-    int addr;
-    unsigned int page; // prevent comparison of unsigned and signed int
     int first_empty_page = -1;
 
     Config config; // Last or (if there hasn't been a config flashed before) default config
@@ -62,15 +60,13 @@ namespace nv_config
                      FLASH_TARGET_OFFSET);
 
         // Read flash until first empty page found
+        unsigned int page; // prevent comparison of unsigned and signed int
         for (page = 0; page < FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE; page++)
         {
-            addr = XIP_BASE + FLASH_TARGET_OFFSET + (page * FLASH_PAGE_SIZE);
-            // p = (int *)addr;
+            int addr = XIP_BASE + FLASH_TARGET_OFFSET + (page * FLASH_PAGE_SIZE);
             Config *ptr = (Config *)addr;
-            // DEBUG_PRINTF("First four bytes of page %d (at 0x%x) = %d\n", page, int(p), *p);
 
-            // Instead of test all of our first Config member, lets cast the struct to a long long int, which has the same size than our struct,
-            // which make test for erased flash pages much easier
+            // Instead testing all of our first config member, lets cast the struct to a long long int, which is save to identify an empty page
             long long trix = *((long long *)ptr);
             DEBUG_PRINTF("Config in page %d (at 0x%x) = config_bitmask: 0b" PRINTF_BINARY_PATTERN_INT8 ", rain_threshold: %d, language: %d, volume: %d, trix: %lld\n ",
                          page, int(ptr), PRINTF_BYTE_TO_BINARY_INT8(ptr->config_bitmask), ptr->rain_threshold, ptr->language, ptr->volume, trix);


### PR DESCRIPTION
In preparation for what we discussed in #80, I wrote some code how I would save a config structure in flash.
I preferred to implement it as described by this great [blog article](https://www.makermatrix.com/blog/read-and-write-data-with-the-pi-pico-onboard-flash/) instead of the common known Arduino EEPROM library, for an improved wear leveling protection.

Attention:
This draft contains some sample/test code which increase config.volume every second (in main.cpp) and for quicker test/debug, wear level protection is shortened to 10 seconds (instead of more protective 1-5 minutes) (in nv_config.h line 29) for changed config members.
So, don't leave it running endless even if expected flash EOL time with this 10 second protection will be after approx. 888 hours (20'000 expected flash erase cycles * 16 wear level protection * 10 seconds write cycle)