### PR TITLE
Implement flexible config req- & response- packages. See PR79 of open…

### DIFF
--- a/Firmware/LowLevel/src/datatypes.h
+++ b/Firmware/LowLevel/src/datatypes.h
@@ -23,6 +23,8 @@
 #define PACKET_ID_LL_STATUS 1
 #define PACKET_ID_LL_IMU 2
 #define PACKET_ID_LL_UI_EVENT 3
+#define PACKET_ID_LL_HIGH_LEVEL_CONFIG_REQ 0x21 // ll_high_level_config and request config from receiver
+#define PACKET_ID_LL_HIGH_LEVEL_CONFIG_RSP 0x22 // ll_high_level_config response
 #define PACKET_ID_LL_HEARTBEAT 0x42
 #define PACKET_ID_LL_HIGH_LEVEL_STATE 0x43
 
@@ -113,6 +115,25 @@ struct ll_ui_event {
     uint8_t type;
     uint8_t button_id; 
     uint8_t press_duration;   // 0 for single press, 1 for long, 2 for very long press
+    uint16_t crc;
+} __attribute__((packed));
+#pragma pack(pop)
+
+#define LL_HIGH_LEVEL_CONFIG_MAX_COMMS_VERSION 1           // Max. comms packet version supported by this open_mower LL FW
+#define LL_HIGH_LEVEL_CONFIG_BIT_DFPIS5V 1 << 0            // Enable full sound via mower_config env var "OM_DFP_IS_5V"
+#define LL_HIGH_LEVEL_CONFIG_BIT_EMERGENCY_INVERSE 1 << 1  // Sample, for possible future usage, i.e. for SA-Type emergency
+
+typedef char iso639_1[2]; // Two char ISO 639-1 language code
+
+#pragma pack(push, 1)
+struct ll_high_level_config {
+    uint8_t type;
+    uint8_t comms_version = LL_HIGH_LEVEL_CONFIG_MAX_COMMS_VERSION;  // Increasing comms packet-version number for packet compatibility (n > 0)
+    uint8_t config_bitmask = 0;                                      // See LL_HIGH_LEVEL_CONFIG_BIT_*
+    int8_t volume;                                                   // Volume (0-100%) feedback (if directly changed via CoverUI)
+    iso639_1 language;                                               // ISO 639-1 (2-char) language code (en, de, ...)
+    uint16_t spare1 = 0;                                             // Spare for future use
+    uint16_t spare2 = 0;                                             // Spare for future use
     uint16_t crc;
 } __attribute__((packed));
 #pragma pack(pop)


### PR DESCRIPTION
Here's how I would implement my newest changes of https://github.com/ClemensElflein/open_mower_ros/pull/79

The main change is now, that LL would send and request a config packet whenever ROS_running is (back) true.
By this we would cover LL as well as HL restarts.