### PR TITLE
Bugfix/wt901 via SerialPIO

### DIFF
--- a/Firmware/LowLevel/lib/JY901_SERIAL/JY901.cpp
+++ b/Firmware/LowLevel/lib/JY901_SERIAL/JY901.cpp
@@ -13,10 +13,10 @@ CJY901 ::CJY901(SerialPIO *serial)
 void CJY901::begin(unsigned long baudrate) {
 	serial->begin(baudrate);
 	delay(1000);
-	/*uint8_t unlock[] = {0xFF,0xF0,0xF0,0xF0,0xF0}; // undocumented / unknown?
+	uint8_t unlock[] = {0xFF,0xF0,0xF0,0xF0,0xF0}; // undocumented but required magic unlock sequence
 	serial->write(unlock, 5);
 	serial->flush();
-	delay(10);*/
+	delay(10);
 	writeRegister(RSW, 0b0000000000010110);  // Return data content
 	delay(10);
 	writeRegister(RRATE, 0x08); // Return rate 0x06 = 10Hz (default), 0x08 = 50Hz, 0x09 = 100Hz

--- a/Firmware/LowLevel/lib/JY901_SERIAL/JY901.cpp
+++ b/Firmware/LowLevel/lib/JY901_SERIAL/JY901.cpp
@@ -10,26 +10,23 @@ CJY901 ::CJY901(SerialPIO *serial)
 	this->serial = serial;
 }
 
-void CJY901::begin(int baudrate) {
+void CJY901::begin(unsigned long baudrate) {
 	serial->begin(baudrate);
 	delay(1000);
-	uint8_t unlock[] = {0xFF,0xF0,0xF0,0xF0,0xF0};
+	/*uint8_t unlock[] = {0xFF,0xF0,0xF0,0xF0,0xF0}; // undocumented / unknown?
 	serial->write(unlock, 5);
 	serial->flush();
+	delay(10);*/
+	writeRegister(RSW, 0b0000000000010110);  // Return data content
 	delay(10);
-	writeRegister(RSW, 0b0000000000010110);
+	writeRegister(RRATE, 0x08); // Return rate 0x06 = 10Hz (default), 0x08 = 50Hz, 0x09 = 100Hz
 	delay(10);
-	writeRegister(RRATE, 0x09);
+	writeRegister(0x0b, 0x00);  // X axis Magnetic bias
 	delay(10);
-	writeRegister(0x0b,0x00);
+	writeRegister(0x0c, 0x00);  // Y axis Magnetic bias
 	delay(10);
-	writeRegister(0x0c,0x00);
+	writeRegister(0x0d, 0x00);  // Z axis Magnetic bias
 	delay(10);
-	writeRegister(0x0d,0x00);
-	delay(10);
-
-
-	
 
 	ucRxCnt = 0;
 }
@@ -43,6 +40,7 @@ void CJY901 ::update()
 		if (ucRxBuffer[0] != 0x55)
 		{
 			ucRxCnt = 0;
+			commsError_ = true;
 			continue;
 		}
 		if (ucRxCnt < 11)
@@ -111,4 +109,10 @@ void CJY901::writeRegister(uint8_t address, uint16_t data) {
 	serial->flush();
 	delay(100);
 	
+}
+
+bool CJY901::commsError() {
+    bool hold = (commsError_ || serial->overflow());
+	commsError_ = false;
+	return hold;
 }

--- a/Firmware/LowLevel/lib/JY901_SERIAL/JY901.cpp
+++ b/Firmware/LowLevel/lib/JY901_SERIAL/JY901.cpp
@@ -112,7 +112,10 @@ void CJY901::writeRegister(uint8_t address, uint16_t data) {
 }
 
 bool CJY901::commsError() {
-    bool hold = (commsError_ || serial->overflow());
-	commsError_ = false;
-	return hold;
+    bool hold = commsError_;
+#ifdef WT901
+    hold |= serial->overflow();
+#endif
+    commsError_ = false;
+    return hold;
 }

--- a/Firmware/LowLevel/lib/JY901_SERIAL/JY901.h
+++ b/Firmware/LowLevel/lib/JY901_SERIAL/JY901.h
@@ -142,15 +142,16 @@ class CJY901
 	struct SGPSV 		stcGPSV;
 	
     #ifdef WT901_INSTEAD_OF_SOUND
-	CJY901 (HardwareSerial *serial); 
+		CJY901 (HardwareSerial *serial);
+    	void begin(unsigned long baudrate = 9600UL);
 	#elif WT901
-	CJY901 (SerialPIO *serial); 
-	#endif 
-	
-	void begin(int baudrate = 9600);
+		CJY901 (SerialPIO *serial);
+		void begin(unsigned long baudrate = 9700UL);  // YES, 9700 baud! See SerialPIO timing issue https://github.com/earlephilhower/arduino-pico/issues/1276
+	#endif
+
 	// Call as often as possible to fetch data from serial
 	void update();
-
+	bool commsError();  // Get (and reset) communication error flag
 	
 	
   private: 
@@ -161,6 +162,7 @@ class CJY901
 	#endif
 	unsigned char ucRxBuffer[250];
 	unsigned char ucRxCnt = 0;	
+	bool commsError_ = false;  // Any kind of communication error
 
 	void writeRegister(uint8_t address, uint16_t data);
 };

--- a/Firmware/LowLevel/src/datatypes.h
+++ b/Firmware/LowLevel/src/datatypes.h
@@ -151,10 +151,4 @@ struct ll_high_level_config {
 } __attribute__((packed));
 #pragma pack(pop)
 
-struct Color {
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
-};
-
 #endif

--- a/Firmware/LowLevel/src/datatypes.h
+++ b/Firmware/LowLevel/src/datatypes.h
@@ -151,4 +151,10 @@ struct ll_high_level_config {
 } __attribute__((packed));
 #pragma pack(pop)
 
+struct Color {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+};
+
 #endif

--- a/Firmware/LowLevel/src/imu.h
+++ b/Firmware/LowLevel/src/imu.h
@@ -8,6 +8,8 @@ bool imu_read(float *acceleration_mss,float *gyro_rads,float *mag_uT);
 // call once per loop, used to process serial or do sensor fusion or do nothing.
 void imu_loop();
 
-bool imu_overflow(); // get IMU serial overflow flag (and reset it)
+#if defined(WT901) || defined(WT901_INSTEAD_OF_SOUND)
+bool imu_comms_error(); // get IMU communication error flag (and reset it)
+#endif
 
 #endif

--- a/Firmware/LowLevel/src/imu.h
+++ b/Firmware/LowLevel/src/imu.h
@@ -8,4 +8,6 @@ bool imu_read(float *acceleration_mss,float *gyro_rads,float *mag_uT);
 // call once per loop, used to process serial or do sensor fusion or do nothing.
 void imu_loop();
 
+bool imu_overflow(); // get IMU serial overflow flag (and reset it)
+
 #endif

--- a/Firmware/LowLevel/src/imu/WT901_SERIAL/imu.cpp
+++ b/Firmware/LowLevel/src/imu/WT901_SERIAL/imu.cpp
@@ -42,3 +42,12 @@ void imu_loop()
 {
     IMU.update();
 }
+
+bool imu_overflow()
+{
+#ifdef WT901
+    return imuSerial.overflow();
+#else
+    return false;
+#endif
+}

--- a/Firmware/LowLevel/src/imu/WT901_SERIAL/imu.cpp
+++ b/Firmware/LowLevel/src/imu/WT901_SERIAL/imu.cpp
@@ -43,11 +43,7 @@ void imu_loop()
     IMU.update();
 }
 
-bool imu_overflow()
+bool imu_comms_error()
 {
-#ifdef WT901
-    return imuSerial.overflow();
-#else
-    return false;
-#endif
+    return IMU.commsError();
 }

--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -548,7 +548,10 @@ void sendConfigMessage(uint8_t pkt_type) {
     ll_config.type = pkt_type;
     ll_config.config_bitmask = config_bitmask;
     ll_config.volume = 80;            // FIXME: Adapt once nv_config or improve-sound got merged
-    strcpy(ll_config.language, "en"); // FIXME: Adapt once nv_config or improve-sound got merged
+    iso639_1 language = {'e', 'n'};   // FIXME: Adapt once nv_config or improve-sound got merged
+    for (unsigned int i = 0; i < sizeof(language); i++) {
+        ll_config.language[i] = language[i];
+    }
     sendMessage(&ll_config, sizeof(struct ll_high_level_config));
 }
 

--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -631,19 +631,24 @@ void updateChargingEnabled() {
 }
 
 void updateNeopixel() {
+    Color color;
     led_blink_counter++;
-    // flash red on emergencies
-    if (emergency_latch && led_blink_counter & 0b10) {
-        p.neoPixelSetValue(0, 128, 0, 0, true);
+
+    if (emergency_latch && led_blink_counter & 0b10) {  // blink on emergencies
+        color = {128, 0, 0};                            // 1/2 red
     } else {
         if (ROS_running) {
-            // Green, if ROS is running
-            p.neoPixelSetValue(0, 0, 255, 0, true);
+            color = {0, 255, 0};  // green
         } else {
-            // Yellow, if it's not running
-            p.neoPixelSetValue(0, 255, 50, 0, true);
+            color = {255, 50, 0};  // yellow
         }
     }
+
+    if (imu_overflow() && led_blink_counter & 0b1) {  // flash on communication error (i.e. serial overflow)
+        color = {255, 0, 255};  // magenta
+    }
+
+    p.neoPixelSetValue(0, color.r, color.g, color.b, true);
 }
 
 void loop() {

--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -631,24 +631,22 @@ void updateChargingEnabled() {
 }
 
 void updateNeopixel() {
-    Color color;
     led_blink_counter++;
 
-    if (emergency_latch && led_blink_counter & 0b10) {  // blink on emergencies
-        color = {128, 0, 0};                            // 1/2 red
+    if (emergency_latch && led_blink_counter & 0b100) {  // slow blink on emergencies
+        p.neoPixelSetValue(0, 128, 0, 0, true);          // 1/2 red
     } else {
         if (ROS_running) {
-            color = {0, 255, 0};  // green
+            p.neoPixelSetValue(0, 0, 255, 0, true);  // green
         } else {
-            color = {255, 50, 0};  // yellow
+            p.neoPixelSetValue(0, 255, 50, 0, true);  // yellow
         }
+#if defined(WT901) || defined(WT901_INSTEAD_OF_SOUND)
+        if (led_blink_counter & 0b10 && imu_comms_error()) {  // fast blink on communication error (condition order matters -> short-circuit evaluation)
+            p.neoPixelSetValue(0, 255, 0, 255, true);         // magenta
+        }
+#endif
     }
-
-    if (imu_overflow() && led_blink_counter & 0b1) {  // flash on communication error (i.e. serial overflow)
-        color = {255, 0, 255};  // magenta
-    }
-
-    p.neoPixelSetValue(0, color.r, color.g, color.b, true);
 }
 
 void loop() {


### PR DESCRIPTION
Got WT901 via SerialPIO now working reliable. Also tested if WT901_INSTEAD_OF_SOUND still works = yes.
It's still draft as I wait for Deyan to test it also (he's on the road for a week), but like to comment before forget ;-)

Neopixel:
For easier communication-error identification (as well as helper during my debugging), I added a magenta color to Neopixel which flashes whenever an overflow or packet error occurs (Pico's LED was a bad idea by me, as it's hidden by RTK2B).
If accepted and merged, we probably should also add other SerialPIO devices to check if they also get affected by the SerialPIO timing issue. "Sound" probably also, but the sound packets are much smaller. CoverUI?!
For this I had to slow down the normal Emergency flash rate by one more bit. Without this, visual identification wasn't possible and you quickly got blind :-/

This PR also contain a tiny nv_config fix for a compiler warning, as long as #80 isn't merged.