### PR TITLE
Shutdown ESCs when IDLE/EMERGENCY

### DIFF
--- a/Firmware/LowLevel/src/datatypes.h
+++ b/Firmware/LowLevel/src/datatypes.h
@@ -101,7 +101,7 @@ struct ll_status {
     // Bit 0: Initialized (i.e. setup() was a success). If this is 0, all other bits are meaningless.
     // Bit 1: Raspberry Power
     // Bit 2: Charging enabled
-    // Bit 3: don't care (reserved for ESC shutdown PR)
+    // Bit 3: ESC power
     // Bit 4: Rain detected
     // Bit 5: Sound available
     // Bit 6: Sound busy
@@ -168,7 +168,7 @@ struct ll_high_level_state {
 struct ll_ui_event {
     // Type of this message. Has to be PACKET_ID_LL_UI_EVENT
     uint8_t type;
-    uint8_t button_id; 
+    uint8_t button_id;
     uint8_t press_duration;   // 0 for single press, 1 for long, 2 for very long press
     uint16_t crc;
 } __attribute__((packed));
@@ -236,7 +236,7 @@ struct ll_high_level_config {
     float v_battery_full = 28.7f - 0.3f;   // Full battery voltage used for % calc of capacity (-1 = unknown)
     uint16_t lift_period = 100;            // Period (ms) for >=2 wheels to be lifted in order to count as emergency (0 = disable, 0xFFFF = unknown). This is to filter uneven ground
     uint16_t tilt_period = 2500;           // Period (ms) for a single wheel to be lifted in order to count as emergency (0 = disable, 0xFFFF = unknown). This is to filter uneven ground
-    uint8_t shutdown_esc_max_pitch = 0;    // Do not shutdown ESCs if absolute pitch angle is greater than this (0 = disable, 0xffff = unknown) (to be implemented, see PR #97)
+    uint8_t shutdown_esc_max_pitch = 0;    // Do not shutdown ESCs if absolute pitch angle is greater than this (0 = disable, 0xffff = unknown)
     iso639_1 language = {'e', 'n'};        // ISO 639-1 (2-char) language code (en, de, ...)
     uint8_t volume = 80;                   // Volume (0-100%) feedback (if directly changed i.e. via CoverUI or WebApp) (0xff = do not change)
     HallConfig hall_configs[MAX_HALL_INPUTS] = {

--- a/Firmware/LowLevel/src/imu/LSM6DSO/imu.cpp
+++ b/Firmware/LowLevel/src/imu/LSM6DSO/imu.cpp
@@ -49,12 +49,16 @@ bool imu_read(float *acceleration_mss, float *gyro_rads, float *mag_uT) {
     success &= IMU.Get_X_Axes(accelerometer) == 0;
     success &= IMU.Get_G_Axes(gyroscope) == 0;
 
-    acceleration_mss[0] = accelerometer[0] * 9.81 / 1000.0;
-    acceleration_mss[1] = accelerometer[1] * 9.81 / 1000.0;
+    // Left down: Y = -g
+    acceleration_mss[1] = accelerometer[0] * 9.81 / 1000.0;
+    // Nose down: X = -g
+    acceleration_mss[0] = -accelerometer[1] * 9.81 / 1000.0;
+    // Flat: Z = +g
     acceleration_mss[2] = accelerometer[2] * 9.81 / 1000.0;
 
-    gyro_rads[0] = gyroscope[0] * (PI / 180.0) / 1000.0;
-    gyro_rads[1] = gyroscope[1] * (PI / 180.0) / 1000.0;
+    // Datasheet shows gyro and acceleromter axes are aligned
+    gyro_rads[1] = -gyroscope[0] * (PI / 180.0) / 1000.0;
+    gyro_rads[0] = gyroscope[1] * (PI / 180.0) / 1000.0;
     gyro_rads[2] = gyroscope[2] * (PI / 180.0) / 1000.0;
 
     mag_uT[0] = 0;

--- a/Firmware/LowLevel/src/imu/MPU9250/imu.cpp
+++ b/Firmware/LowLevel/src/imu/MPU9250/imu.cpp
@@ -20,14 +20,20 @@ bool imu_read(float *acceleration_mss, float *gyro_rads, float *mag_uT)
 {
     IMU.readSensor();
 
-    acceleration_mss[0] = IMU.getAccelX_mss();
-    acceleration_mss[1] = IMU.getAccelY_mss();
+    // TODO: test this
+    // Left down: Y = -g
+    acceleration_mss[1] = -IMU.getAccelX_mss();
+    // Nose down: X = -g
+    acceleration_mss[0] = IMU.getAccelY_mss();
+    // Flat: Z = +g
     acceleration_mss[2] = IMU.getAccelZ_mss();
 
-    gyro_rads[0] = IMU.getGyroX_rads();
-    gyro_rads[1] = IMU.getGyroY_rads();
+    // MPU-9250 Datasheet shows gyro and acceleromter axes are aligned
+    gyro_rads[1] = -IMU.getGyroX_rads();
+    gyro_rads[0] = IMU.getGyroY_rads();
     gyro_rads[2] = -IMU.getGyroZ_rads();
 
+    // Mag is NED coordinates
     mag_uT[0] = IMU.getMagX_uT();
     mag_uT[1] = IMU.getMagY_uT();
     mag_uT[2] = IMU.getMagZ_uT();

--- a/Firmware/LowLevel/src/imu/WT901_I2C/imu.cpp
+++ b/Firmware/LowLevel/src/imu/WT901_I2C/imu.cpp
@@ -23,6 +23,7 @@ bool imu_read(float *acceleration_mss, float *gyro_rads, float *mag_uT)
     IMU.GetMag();
     IMU.GetGyro();
 
+    // WT901 axes seem to be corrected?
     acceleration_mss[0] = (float)IMU.stcAcc.a[0] / 32768.0f * 16.0f * 9.81f;
     acceleration_mss[1] = (float)IMU.stcAcc.a[1] / 32768.0f * 16.0f * 9.81f;
     acceleration_mss[2] = (float)IMU.stcAcc.a[2] / 32768.0f * 16.0f * 9.81f;

--- a/Firmware/LowLevel/src/imu/WT901_SERIAL/imu.cpp
+++ b/Firmware/LowLevel/src/imu/WT901_SERIAL/imu.cpp
@@ -23,6 +23,7 @@ bool init_imu()
 
 bool imu_read(float *acceleration_mss, float *gyro_rads, float *mag_uT)
 {
+    // WT901 axes seem to be corrected?
     acceleration_mss[0] = (float)IMU.stcAcc.a[0] / 32768.0f * 16.0f * 9.81f;
     acceleration_mss[1] = (float)IMU.stcAcc.a[1] / 32768.0f * 16.0f * 9.81f;
     acceleration_mss[2] = (float)IMU.stcAcc.a[2] / 32768.0f * 16.0f * 9.81f;

--- a/configs/xESC/YardForce_Classic_Drive_App.xml
+++ b/configs/xESC/YardForce_Classic_Drive_App.xml
@@ -15,7 +15,7 @@
     <uavcan_raw_mode>0</uavcan_raw_mode>
     <uavcan_raw_rpm_max>50000</uavcan_raw_rpm_max>
     <servo_out_enable>0</servo_out_enable>
-    <kill_sw_mode>0</kill_sw_mode>
+    <kill_sw_mode>4</kill_sw_mode>
     <app_to_use>3</app_to_use>
     <app_ppm_conf.ctrl_type>0</app_ppm_conf.ctrl_type>
     <app_ppm_conf.pid_max_erpm>15000</app_ppm_conf.pid_max_erpm>

--- a/configs/xESC/YardForce_Classic_Mower_App.xml
+++ b/configs/xESC/YardForce_Classic_Mower_App.xml
@@ -15,7 +15,7 @@
     <uavcan_raw_mode>0</uavcan_raw_mode>
     <uavcan_raw_rpm_max>50000</uavcan_raw_rpm_max>
     <servo_out_enable>0</servo_out_enable>
-    <kill_sw_mode>0</kill_sw_mode>
+    <kill_sw_mode>4</kill_sw_mode>
     <app_to_use>3</app_to_use>
     <app_ppm_conf.ctrl_type>0</app_ppm_conf.ctrl_type>
     <app_ppm_conf.pid_max_erpm>15000</app_ppm_conf.pid_max_erpm>


### PR DESCRIPTION
Align IMU accelerometer axes.
Calculate pitch, roll, and overall tilt angles.

Set ESC shutdown pin to HIGH if:
  - shutdown_esc_max_pitch is set
  - not on a slope (pitch < shutdown_esc_max_pitch) and...
  - ROS is running and...
  - current mode is IDLE or emergency latched

Requires killswitch to be set to ADC2_HIGH in xesc app config

(Based on the work of @Pete_MI632 on discord)