### PR TITLE
Fix typo

### DIFF
--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -156,7 +156,7 @@ void updateEmergency() {
     uint8_t emergency_state = 0;
 
     // Handle emergency "Stop" buttons
-    if (emergency_read && LL_EMERGENCY_BITS_STOP) {
+    if (emergency_read & LL_EMERGENCY_BITS_STOP) {
         // If we just pressed, store the timestamp
         if (button_emergency_started == 0) {
             button_emergency_started = millis();


### PR DESCRIPTION
~~Otherwise whenever *any* hall sensor triggers, it will trigger the STOP emergency bits after just 20 ms, instead of waiting 2500 ms (for tilt) or 100 ms (for lift).~~
Actually no, because only bits which are really in `emergency_read` are set. So worst case would be that some other hall sensor triggers the timer too early. It's still wrong though.

Already confirmed with @Apehaenger that this wasn't intended.