### PR TITLE
Improve battery handling

### DIFF
--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -82,12 +82,12 @@ SerialPIO uiSerial(PIN_UI_TX, PIN_UI_RX, 250);
 #define BATT_EMPTY BATT_ABS_Min + 0.3f
 
 // Make some corrections to the ADC values. Assuming the error is linear the value from the adc is multiplied by the "FACTOR" and then "OFFSET" is added.
-#define ADC_BATTERY_CORRECTION_FACTOR 1.04f
-#define ADC_BATTERY_CORRECTION_OFFSET -0.2f
-#define ADC_CHARGE_CORRECTION_FACTOR 1.05f
-#define ADC_CHARGE_CORRECTION_OFFSET -0.4f
-#define ADC_CHARGE_CURRENT_CORRECTION_FACTOR 1.12f
-#define ADC_CHARGE_CURRENT_CORRECTION_OFFSET -0.4f
+#define ADC_BATTERY_CORRECTION_FACTOR 1.0f
+#define ADC_BATTERY_CORRECTION_OFFSET 0
+#define ADC_CHARGE_CORRECTION_FACTOR 1.0f
+#define ADC_CHARGE_CORRECTION_OFFSET 0
+#define ADC_CHARGE_CURRENT_CORRECTION_FACTOR 1.0f
+#define ADC_CHARGE_CURRENT_CORRECTION_OFFSET 0
 
 // To avoid charge/discharge toggling don't restart charging until the battery voltage is below the value below.
 #define BATT_FULL_HYSTERESIS BATT_FULL - 1.0f


### PR DESCRIPTION
The values given by the ADC are not very accurate. The introduced errors pose a risk for over-voltage on the battery, which in worst case can lead to an explosion.

This commit aims to mitigate the above by doing the following:

* Adding correction values in order for the reported values to match the real ones
* Adding IIR filter (from Jahnkeanater) to get more smooth readings
* Adding hysteresis for when to restart charging, to avoid charge/discharge toggling