### PR TITLE
Feature/LSM6DSO

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,10 @@ jobs:
           cp Firmware/LowLevel/.pio/build/0_11_X_WT901/firmware.elf ./artifacts/0_11_X_WT901
           cp Firmware/LowLevel/.pio/build/0_11_X_WT901/firmware.uf2 ./artifacts/0_11_X_WT901
           
+          mkdir ./artifacts/0_11_X_LSM6DSO
+          cp Firmware/LowLevel/.pio/build/0_11_X_LSM6DSO/firmware.elf ./artifacts/0_11_X_LSM6DSO
+          cp Firmware/LowLevel/.pio/build/0_11_X_LSM6DSO/firmware.uf2 ./artifacts/0_11_X_LSM6DSO
+          
           mkdir ./artifacts/0_10_X_MPU9250
           cp Firmware/LowLevel/.pio/build/0_10_X_MPU9250/firmware.elf ./artifacts/0_10_X_MPU9250
           cp Firmware/LowLevel/.pio/build/0_10_X_MPU9250/firmware.uf2 ./artifacts/0_10_X_MPU9250
@@ -103,6 +107,10 @@ jobs:
           mkdir ./artifacts/0_10_X_WT901
           cp Firmware/LowLevel/.pio/build/0_10_X_WT901/firmware.elf ./artifacts/0_10_X_WT901
           cp Firmware/LowLevel/.pio/build/0_10_X_WT901/firmware.uf2 ./artifacts/0_10_X_WT901
+          
+          mkdir ./artifacts/0_10_X_LSM6DSO
+          cp Firmware/LowLevel/.pio/build/0_10_X_LSM6DSO/firmware.elf ./artifacts/0_10_X_LSM6DSO
+          cp Firmware/LowLevel/.pio/build/0_10_X_LSM6DSO/firmware.uf2 ./artifacts/0_10_X_LSM6DSO
           
           mkdir ./artifacts/0_9_X_MPU9250
           cp Firmware/LowLevel/.pio/build/0_9_X_MPU9250/firmware.elf ./artifacts/0_9_X_MPU9250
@@ -115,7 +123,11 @@ jobs:
           mkdir ./artifacts/0_9_X_WT901_INSTEAD_OF_SOUND
           cp Firmware/LowLevel/.pio/build/0_9_X_WT901_INSTEAD_OF_SOUND/firmware.elf ./artifacts/0_9_X_WT901_INSTEAD_OF_SOUND
           cp Firmware/LowLevel/.pio/build/0_9_X_WT901_INSTEAD_OF_SOUND/firmware.uf2 ./artifacts/0_9_X_WT901_INSTEAD_OF_SOUND
-          
+
+          mkdir ./artifacts/0_9_X_LSM6DSO
+          cp Firmware/LowLevel/.pio/build/0_9_X_LSM6DSO/firmware.elf ./artifacts/0_9_X_LSM6DSO
+          cp Firmware/LowLevel/.pio/build/0_9_X_LSM6DSO/firmware.uf2 ./artifacts/0_9_X_LSM6DSO
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Firmware/LowLevel/platformio.ini
+++ b/Firmware/LowLevel/platformio.ini
@@ -81,6 +81,15 @@ lib_deps = ${env.lib_deps}
            JY901_I2C
 build_flags = ${env.build_flags} -DWT901_I2C -DHW_0_11_X -DENABLE_SOUND_MODULE
 
+[env:0_11_X_LSM6DSO]
+build_src_filter = ${env.build_src_filter} +<imu/LSM6DSO/>
+lib_ignore = JY901_SERIAL,JY901_I2C
+lib_deps = ${env.lib_deps}
+           ${sound.lib_deps}
+           stm32duino/STM32duino LSM6DSO@^2.0.3
+           jpiat/PioSPI@^0.0.1
+build_flags = ${env.build_flags} -DHW_0_11_X -DENABLE_SOUND_MODULE
+
 
 [env:0_10_X_MPU9250]
 lib_ignore = JY901_SERIAL,JY901_I2C
@@ -97,6 +106,15 @@ lib_deps = ${env.lib_deps}
            ${sound.lib_deps}
            JY901_I2C
 build_flags = ${env.build_flags} -DWT901_I2C -DHW_0_10_X -DENABLE_SOUND_MODULE
+
+[env:0_10_X_LSM6DSO]
+build_src_filter = ${env.build_src_filter} +<imu/LSM6DSO/>
+lib_ignore = JY901_SERIAL,JY901_I2C
+lib_deps = ${env.lib_deps}
+           ${sound.lib_deps}
+           stm32duino/STM32duino LSM6DSO@^2.0.3
+           jpiat/PioSPI@^0.0.1
+build_flags = ${env.build_flags} -DHW_0_10_X -DENABLE_SOUND_MODULE
 
 
 [env:0_9_X_MPU9250]

--- a/Firmware/LowLevel/platformio.ini
+++ b/Firmware/LowLevel/platformio.ini
@@ -121,3 +121,11 @@ lib_deps = ${env.lib_deps}
            ${sound.lib_deps}
            JY901_SERIAL
 build_flags = ${env.build_flags} -DWT901 -DHW_0_9_X -DENABLE_SOUND_MODULE
+
+[env:0_9_X_LSM6DSO]
+lib_ignore = JY901_SERIAL,JY901_I2C
+build_src_filter = ${env.build_src_filter} +<imu/LSM6DSO/>
+lib_deps = ${env.lib_deps}
+           ${sound.lib_deps}
+           stm32duino/STM32duino LSM6DSO@^2.0.3
+build_flags = ${env.build_flags} -DHW_0_9_X -DENABLE_SOUND_MODULE

--- a/Firmware/LowLevel/src/imu/LSM6DSO/imu.cpp
+++ b/Firmware/LowLevel/src/imu/LSM6DSO/imu.cpp
@@ -2,8 +2,8 @@
 #include "pins.h"
 #include <LSM6DSOSensor.h>
 
-#ifdef HW_0_12_X
-// Needs software UART because pins were messed up in 0.12
+#if defined(HW_0_10_X) || defined(HW_0_11_X) || defined(HW_0_12_X)
+// Needs software SPI because pins were messed up in 0.10-0.12
 #include <PioSPI.h>
 PioSPI spiBus(PIN_IMU_MOSI, PIN_IMU_MISO, PIN_IMU_SCK, PIN_IMU_CS, SPI_MODE3, 1000000);
 #else
@@ -16,7 +16,7 @@ int32_t accelerometer[3];
 int32_t gyroscope[3];
 
 bool init_imu() {
-#ifdef HW_0_12_X
+#if defined(HW_0_10_X) || defined(HW_0_11_X) || defined(HW_0_12_X)
   spiBus.begin();
 #else
   spiBus.setCS(PIN_IMU_CS);

--- a/Firmware/LowLevel/src/pins.h
+++ b/Firmware/LowLevel/src/pins.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #ifdef HW_0_9_X
-#define PIN_IMU_CS 17
 #define PIN_ANALOG_BATTERY_VOLTAGE 27
 #define PIN_ANALOG_CHARGE_VOLTAGE 26
 #define PIN_ANALOG_CHARGE_CURRENT 28
@@ -32,15 +31,21 @@
 #define PIN_SOUND_RX 9
 #endif
 
-#ifdef WT901_INSTEAD_OF_SOUND
+// IMU Variants
+#ifdef WT901_INSTEAD_OF_SOUND  // WT901 via HardwareSerial
 #ifdef ENABLE_SOUND_MODULE
 #error you can not enable sound and have wt901 on sound port at the same time.
 #endif
 #define PIN_WT901_TX 8
 #define PIN_WT901_RX 9
-#elif WT901 //This is to use WT901 on MPU9250 Slot via Serial.
+#elif WT901  // WT901 on MPU9250 Slot via SerialPIO.
 #define PIN_WT901_TX 17
 #define PIN_WT901_RX 16
+#else
+#define PIN_IMU_CS 17   // MPU9250
+#define PIN_IMU_RX 16   // LSM6DSx
+#define PIN_IMU_TX 19   // LSM6DSx
+#define PIN_IMU_SCK 18  // LSM6DSx
 #endif
 
 #elif HW_0_10_X || HW_0_11_X || HW_0_12_X


### PR DESCRIPTION
Add support for LSM6DSO IMU in J20 for 0.9.x-0.11.x, but should also be usable as replacement of probably broken or malfunction LSM6DSO for 0.12.x-0.13.x
