### PR TITLE
Ensure PIN_ENABLE_CHARGE is high when undocked to allow regen

### DIFF
--- a/Firmware/LowLevel/src/main.cpp
+++ b/Firmware/LowLevel/src/main.cpp
@@ -686,6 +686,12 @@ bool checkShouldCharge() {
 }
 
 void updateChargingEnabled() {
+    // Always enable for regen when not docked
+    if (status_message.v_charge < 3.0f) {
+        digitalWrite(PIN_ENABLE_CHARGE, HIGH);
+        charging_allowed = false; // For high level status
+        return;
+    }
     if (charging_allowed) {
         if (!checkShouldCharge()) {
             digitalWrite(PIN_ENABLE_CHARGE, LOW);


### PR DESCRIPTION
Ensure charging is enabled while mowing so that the regen current from the mow motor can flow to the battery