### PR TITLE
Stick to older framework for jpiat/PioSPI compatibility

### DIFF
--- a/Firmware/LowLevel/platformio.ini
+++ b/Firmware/LowLevel/platformio.ini
@@ -17,6 +17,13 @@ default_src_filter = +<*>
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = pico
 framework = arduino
+
+; Latest (known) version which compiles well with jpiat/PioSPI.
+; framework-arduinopico >= 4.4.3 will have a (PIO-Assembly driven) SoftwareSPI implementation which would make jpiat/PioSPI needless,
+; but I currently have no mainboard with LSM6DSO here for testing. So stick to the last working version till someone can switch & test it.
+platform_packages =
+    framework-arduinopico @ https://github.com/earlephilhower/arduino-pico.git#4.3.0
+
 board_build.core = earlephilhower
 board_build.filesystem_size = 64k
 


### PR DESCRIPTION
The updated framework-arduinopico isn't compatible with jpiat/PioSPI implementation anymore.
framework-arduinopico >= 4.4.3 has a (PIO-Assembly driven) SoftwareSPI implementation which would make jpiat/PioSPI needless, but I currently have no mainboard with LSM6DSO here for testing.

So stick to the last working framework-arduinopico version till someone can switch & test it.

(DRC check still fails)