### PR TITLE
Drop PioSPI and unpin arduino-pico

### DIFF
--- a/Firmware/LowLevel/platformio.ini
+++ b/Firmware/LowLevel/platformio.ini
@@ -18,12 +18,6 @@ platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = pico
 framework = arduino
 
-; Latest (known) version which compiles well with jpiat/PioSPI.
-; framework-arduinopico >= 4.4.3 will have a (PIO-Assembly driven) SoftwareSPI implementation which would make jpiat/PioSPI needless,
-; but I currently have no mainboard with LSM6DSO here for testing. So stick to the last working version till someone can switch & test it.
-platform_packages =
-    framework-arduinopico @ https://github.com/earlephilhower/arduino-pico.git#4.3.0
-
 board_build.core = earlephilhower
 board_build.filesystem_size = 64k
 
@@ -67,7 +61,7 @@ lib_ignore = JY901_SERIAL,JY901_I2C
 lib_deps = ${env.lib_deps}
            ${sound.lib_deps}
            stm32duino/STM32duino LSM6DSO@^2.0.3
-           jpiat/PioSPI@^0.0.1
+           SoftwareSPI@^1.0
 build_src_filter = ${env.build_src_filter} +<imu/LSM6DSO/>
 build_flags = ${env.build_flags} -DHW_0_12_X -DENABLE_SOUND_MODULE
 
@@ -94,7 +88,7 @@ lib_ignore = JY901_SERIAL,JY901_I2C
 lib_deps = ${env.lib_deps}
            ${sound.lib_deps}
            stm32duino/STM32duino LSM6DSO@^2.0.3
-           jpiat/PioSPI@^0.0.1
+           SoftwareSPI@^1.0
 build_flags = ${env.build_flags} -DHW_0_11_X -DENABLE_SOUND_MODULE
 
 
@@ -120,7 +114,7 @@ lib_ignore = JY901_SERIAL,JY901_I2C
 lib_deps = ${env.lib_deps}
            ${sound.lib_deps}
            stm32duino/STM32duino LSM6DSO@^2.0.3
-           jpiat/PioSPI@^0.0.1
+           SoftwareSPI@^1.0
 build_flags = ${env.build_flags} -DHW_0_10_X -DENABLE_SOUND_MODULE
 
 

--- a/Firmware/LowLevel/src/imu/LSM6DSO/imu.cpp
+++ b/Firmware/LowLevel/src/imu/LSM6DSO/imu.cpp
@@ -4,8 +4,8 @@
 
 #if defined(HW_0_10_X) || defined(HW_0_11_X) || defined(HW_0_12_X)
 // Needs software SPI because pins were messed up in 0.10-0.12
-#include <PioSPI.h>
-PioSPI spiBus(PIN_IMU_MOSI, PIN_IMU_MISO, PIN_IMU_SCK, PIN_IMU_CS, SPI_MODE3, 1000000);
+#include <SoftwareSPI.h>
+SoftwareSPI spiBus(PIN_IMU_SCK, PIN_IMU_MISO, PIN_IMU_MOSI);
 #else
 #include <SPI.h>
 #define spiBus SPI


### PR DESCRIPTION
Pinning ardunio-pico to an older version in 3c5f75103aad2a155e7a7e50a570586d5fd2d655 caused issues with serial I/O on some boards (definitely my 0.11, and similar reports for a 0.13).

Switch back to the current arduino-pico version by replacing PioSPI with SoftwareSPI from arduino-pico.

Tested on 0.12.x board, which uses PIO SPI for the IMU.