### PR TITLE
fix(ci): correct api.openmower.de notify endpoint and auth

### DIFF
--- a/.github/workflows/os-build.yaml
+++ b/.github/workflows/os-build.yaml
@@ -242,7 +242,6 @@ jobs:
               is_release: $is_release, tag_name: $tag_name, repo: $repo,
               run_id: $run_id, artifact_name: $artifact_name}')
           curl --fail --silent --show-error \
-            -H "Authorization: Bearer $TOKEN" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD" \
-            https://api.openmower.de/os-builds
+            "https://api.openmower.de/v1/os-build?build-key=$TOKEN"


### PR DESCRIPTION
## Summary
- The "Notify api.openmower.de" step in `os-build.yaml` posts to `https://api.openmower.de/os-builds` with `Authorization: Bearer $TOKEN`.
- The deployed endpoint is actually `/v1/os-build` (every endpoint on that API lives under `/v1`) and authenticates via a `build-key` query param, not a bearer header — same pattern as that API's existing `/v1/hook` webhook.
- As written, this call 404s on the URL before auth is even checked, so builds currently never make it into api.openmower.de's `os_build` table (confirmed by reading the deployed backend's source — payload field names/types all already match, it's just the URL + auth that don't).
- Fix: point at `https://api.openmower.de/v1/os-build?build-key=$TOKEN`, drop the `Authorization` header.

No functional change to what gets sent — `OPENMOWER_API_TOKEN` still holds the same shared secret, just passed the way the endpoint actually expects it.

## Test plan
- [ ] Set `OPENMOWER_API_TOKEN` repo secret to the value configured as api.openmower.de's `os-build-key`, trigger via `workflow_dispatch`, confirm the notify step returns 200 instead of a 404/curl failure.